### PR TITLE
Update Function for Receiving Serial Data

### DIFF
--- a/rmcs_ws/src/rmcs_core/src/hardware/ec/status.cpp
+++ b/rmcs_ws/src/rmcs_core/src/hardware/ec/status.cpp
@@ -1,6 +1,7 @@
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp/node.hpp>
+#include <rmcs_description/robotic_description.hpp>
 #include <rmcs_description/tf_description.hpp>
 #include <rmcs_executor/component.hpp>
 #include <serial/serial.h>
@@ -30,17 +31,20 @@ public:
 
         register_output("/serial", serial_, path, 9600, serial::Timeout::simpleTimeout(0));
         register_output("/tf", tf_);
+        register_output("/robot_id", robot_id_);
+        register_output("/auto_rune", auto_rune_);
+        register_output("/robot_color", color_);
     }
     ~Status() = default;
 
     void update() override {
         while (true) {
             auto result = serial_util::receive_package(
-                *serial_, package_, cache_size_, static_cast<uint8_t>(0xaf),
+                *serial_, package_, cache_size_, static_cast<uint8_t>(header_),
                 [](const PackageReceive& package) {
-                    if (package.type != 0x32)
+                    if (package.type != type_)
                         return false;
-                    if (package.data_size != 16)
+                    if (package.data_size != size_)
                         return false;
                     auto* data = reinterpret_cast<const uint8_t*>(&package);
                     return package.check_sum
@@ -52,7 +56,7 @@ public:
                 return;
             if (result == serial_util::ReceiveResult::SUCCESS) {
                 cache_size_ = 0;
-                update_quaternion();
+                update_data();
                 if (!successfully_received_) {
                     successfully_received_ = true;
                     RCLCPP_INFO(logger_, "Successfully received the first package");
@@ -74,29 +78,45 @@ public:
     }
 
 private:
-    void update_quaternion() {
+    void update_data() {
         auto gimbal_imu_pose = Eigen::Quaterniond{package_.w, package_.x, package_.y, package_.z};
         tf_->set_transform<rmcs_description::ImuLink, rmcs_description::OdomImu>(
             gimbal_imu_pose.conjugate());
+
+        *auto_rune_ = package_.auto_rune;
+        *robot_id_  = package_.robot_id > 100 ? package_.robot_id - 100 : package_.robot_id;
+        *color_     = package_.robot_id > 100 ? rmcs_description::RoboticColor::Blue
+                                              : rmcs_description::RoboticColor::Red;
     }
 
     FpsCounter fps_counter_;
 
     rclcpp::Logger logger_;
 
+    OutputInterface<uint8_t> robot_id_;
+    OutputInterface<rmcs_description::RoboticColor> color_;
+    OutputInterface<uint8_t> auto_rune_;
     OutputInterface<serial::Serial> serial_;
+
     struct __attribute__((packed)) PackageReceive {
         uint8_t head;
         uint8_t type;
         uint8_t index;
         uint8_t data_size;
         float w, x, y, z;
+        uint8_t robot_id;
+        uint8_t auto_rune;
         uint8_t check_sum;
     } package_;
     size_t cache_size_ = 0;
 
     bool successfully_received_ = false;
     int failures_count_         = 0;
+
+    // Package static data
+    static const inline uint8_t header_ = 0xaf;
+    static const inline uint8_t type_   = 0x32;
+    static const inline uint8_t size_   = 0x12;
 
     OutputInterface<rmcs_description::Tf> tf_;
 };

--- a/rmcs_ws/src/rmcs_description/include/rmcs_description/robotic_description.hpp
+++ b/rmcs_ws/src/rmcs_description/include/rmcs_description/robotic_description.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+namespace rmcs_description {
+enum class RoboticColor : uint8_t {
+    Blue    = 0, // Blue
+    Red     = 1, // Red
+    Neutral = 2, // Neutral Part
+};
+}


### PR DESCRIPTION
# Synopsis
## Feature:
 - Receive robotic color, id and _auto_rune_ from Serial.
 - Define robotic color descriptor(see [rmcs_descripton::RoboticColor](https://github.com/Alliance-Algorithm/RMCS/compare/omni...uart_develop#diff-0c4254aca4ef8f6df2f0d3aa70ff4afa5006ce1778e9deffc0034d7ba4f5b1d8)).
## Refactor:
 - Rewrite update_quaternion to update additional data.
 - Adopt static const variables to describe package header.

# New Output Interface
##  /robot_id

- **Type**: uint8_t
- **Value Description**: 1 for Hero, 2 for Engineer, etc.

## /auto_rune

- **Type**: uint8_t
- **Value Description**: 0 for shooting rune while 1 for not.

## /robot_color

- **Type**: rmcs_description::RoboticColor
- **Value Description**:  rmcs_description::RoboticColor::Blue = 0, rmcs_description::RoboticColor::Red = 1