### PR TITLE
feat(nav): Add deps for slam building and a tool for pcd saving

### DIFF
--- a/.script/complete/_save-map-once
+++ b/.script/complete/_save-map-once
@@ -1,0 +1,4 @@
+#compdef save-map-once
+
+_arguments \
+  '1:mode:(remote local)'

--- a/.script/save-map-once
+++ b/.script/save-map-once
@@ -1,0 +1,45 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: save-map-once <remote|local>
+
+  remote  Trigger robot-side /save_pcd_map service via ssh remote.
+  local   Trigger local container /save_pcd_map service.
+EOF
+}
+
+if (( $# != 1 )); then
+    usage
+    exit 1
+fi
+
+readonly mode="$1"
+readonly service_call='ros2 service call /save_pcd_map std_srvs/srv/Trigger "{}"'
+
+call_local() {
+    bash -lc "source ~/env_setup.bash && ${service_call}"
+}
+
+call_remote() {
+    ssh-remote "bash -lc 'source ~/env_setup.bash && ${service_call}'"
+}
+
+case "$mode" in
+remote)
+    call_remote
+    ;;
+local)
+    call_local
+    ;;
+--help|-h)
+    usage
+    ;;
+*)
+    echo "Error: unsupported mode '$mode'."
+    usage
+    exit 1
+    ;;
+esac

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     > /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
+    libomp-${LLVM_VERSION}-dev \
     clang-${LLVM_VERSION} clangd-${LLVM_VERSION} clang-format-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} \
     lldb-${LLVM_VERSION} lld-${LLVM_VERSION} llvm-${LLVM_VERSION} && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 50 && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PR摘要

本PR为SLAM构建添加必要依赖，并引入一个用于保存 PCD 地图的命令行工具与其补全脚本。

### 主要改动

1. 新增 PCD 地图保存工具（.script/save-map-once）
- 可执行 Zsh 脚本：Usage: save-map-once <remote|local>
- 支持两种模式：
  - remote：通过 ssh-remote 在机器人端触发 ROS2 服务 /save_pcd_map
  - local：在本地（容器）环境触发 /save_pcd_map
- 使用严格的 shell 选项（set -euo pipefail），包含参数检查与帮助信息
- 通过 source ~/env_setup.bash 设置环境，service 调用由变量 service_call 指定

2. 新增 Zsh 补全脚本（.script/complete/_save-map-once）
- 为 save-map-once 命令添加补全，限定第一个参数可选值为 remote 和 local

3. Dockerfile 依赖更新
- 在 llvm-toolchain 安装阶段添加 libomp-${LLVM_VERSION}-dev，以支持 OpenMP（利于 SLAM 构建的并行需求）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->