### PR TITLE
feat: include micro-xrce-dds in runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ SHELL ["/bin/bash", "-c"]
 ENV TZ=Asia/Shanghai \
     DEBIAN_FRONTEND=noninteractive
 
+ARG FASTDDS_TAG=v2.12.2
+ARG MICROXRCE_AGENT_TAG=v2.4.2
+
 # Install tools and libraries.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     vim wget curl unzip \
@@ -55,6 +58,30 @@ RUN git clone https://github.com/Livox-SDK/Livox-SDK2.git && \
     make -j && \
     make install && \
     cd ../.. && rm -rf Livox-SDK2
+
+# Install Micro XRCE-DDS Agent as a standalone dependency in rmcs-base.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libasio-dev && \
+    git clone --branch "${MICROXRCE_AGENT_TAG}" --depth 1 https://github.com/eProsima/Micro-XRCE-DDS-Agent.git /tmp/Micro-XRCE-DDS-Agent && \
+    sed -Ei "s|(set\\(_fastdds_tag )[^)]*(\\))|\\1${FASTDDS_TAG}\\2|" /tmp/Micro-XRCE-DDS-Agent/CMakeLists.txt && \
+    cmake -S /tmp/Micro-XRCE-DDS-Agent -B /tmp/micro-xrce-dds-agent-build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DUAGENT_SUPERBUILD=ON \
+        -DUAGENT_BUILD_EXECUTABLE=ON \
+        -DUAGENT_USE_SYSTEM_FASTCDR=OFF \
+        -DUAGENT_USE_SYSTEM_FASTDDS=OFF \
+        -DUAGENT_LOGGER_PROFILE=OFF \
+        -DUAGENT_P2P_PROFILE=OFF \
+        -DCMAKE_PREFIX_PATH="/opt/ros/${ROS_DISTRO}" && \
+    cmake --build /tmp/micro-xrce-dds-agent-build --target uagent -j"$(nproc)" && \
+    agent_bin="$(find /tmp/micro-xrce-dds-agent-build -type f -name MicroXRCEAgent -print -quit)" && \
+    test -n "${agent_bin}" && \
+    install -Dm755 "${agent_bin}" /usr/local/bin/MicroXRCEAgent && \
+    apt-get purge -y --auto-remove libasio-dev && \
+    apt-get autoremove -y && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Mount rmcs source and install dependencies
 RUN --mount=type=bind,target=/rmcs_ws/src,source=rmcs_ws/src,readonly \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 功能特性

在运行时容器的 rmcs-base 阶段中直接从源码构建并包含 Micro XRCE-DDS Agent，可在容器内以可执行文件形式提供 MicroXRCEAgent。

## 变更详情

### Dockerfile

- 新增构建参数：
  - ARG FASTDDS_TAG=v2.12.2
  - ARG MICROXRCE_AGENT_TAG=v2.4.2

- 在 rmcs-base 阶段新增一个 RUN 块以作为独立依赖构建步骤，主要操作：
  - 安装构建依赖 libasio-dev。
  - 克隆指定分支/标签的 Micro-XRCE-DDS-Agent（使用 MICROXRCE_AGENT_TAG）。
  - 修改其 CMakeLists.txt，将内部设置的 Fast-DDS 版本替换为 FASTDDS_TAG。
  - 使用 CMake（启用 UAGENT_SUPERBUILD 并关闭使用系统 Fast-CDR/Fast-DDS）配置并构建 uagent 可执行目标。
  - 将构建产物中的 MicroXRCEAgent 可执行文件安装到 /usr/local/bin/MicroXRCEAgent。
  - 卸载 libasio-dev，清理 apt 缓存与临时文件。

- 在 rmcs-base 中，在挂载并安装 rmcs_ws 依赖（rosdep）之前完成上述 Micro XRCE-DDS Agent 的源码构建，使运行时镜像包含已编译的 agent 可执行文件。

## 导出/公共声明变更

- Dockerfile 增加了两个构建参数（FASTDDS_TAG、MICROXRCE_AGENT_TAG）。

## 其他说明

- 构建步骤采用 superbuild 方式构建 agent，可通过 FASTDDS_TAG 控制所用 Fast-DDS 版本；但 Dockerfile 中通过 CMake 配置关闭了使用系统 Fast-CDR/Fast-DDS（DUAGENT_USE_SYSTEM_FASTCDR=OFF、DUAGENT_USE_SYSTEM_FASTDDS=OFF），由 superbuild 处理依赖构建与链接。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->