### PR TITLE
chore: better set-remote script

### DIFF
--- a/.script/set-remote
+++ b/.script/set-remote
@@ -1,275 +1,387 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
-import sys
-import re
 import os
+import re
+import sys
+import termios
 
 from colorama import Fore, Style
 
 
-def main():
-    if len(sys.argv) <= 1 or len(sys.argv) > 2 or sys.argv[1] in ("-h", "--help"):
-        print("Usage: set-remote <remote_host>")
-        print("    1. IPv4 / IPv6 address (e.g., 169.254.233.233)")
-        print(
-            "    2. IPv4 / IPv6 link-local address (e.g., fe80::c6d0:e3ff:fed7:ed12%eth0)"
+# ============================================================
+# Terminal — spinner, raw input, prompt drawing
+# ============================================================
+
+class Terminal:
+    SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def __init__(self):
+        self._fd = sys.stdin.fileno()
+        self.buf = ""
+
+    def __enter__(self):
+        self._old = termios.tcgetattr(self._fd)
+        new = termios.tcgetattr(self._fd)
+        new[3] &= ~(termios.ECHO | termios.ICANON)
+        new[6][termios.VMIN] = 1
+        new[6][termios.VTIME] = 0
+        termios.tcsetattr(self._fd, termios.TCSANOW, new)
+        return self
+
+    def __exit__(self, *_):
+        termios.tcsetattr(self._fd, termios.TCSANOW, self._old)
+
+    def draw(self, discovered):
+        i = int(__import__("time").time() * 15) % len(self.SPINNER)
+        sp = self.SPINNER[i]
+        prompt = (
+            "Enter index to select or Ctrl+C to exit: "
+            if discovered
+            else "No addresses found. Enter index or Ctrl+C to exit: "
         )
-        print("    3. mDNS hostname (e.g., my-sentry.local)")
-        sys.exit(1)
+        sys.stdout.write(f"\r\033[K{sp} {prompt}{self.buf}")
+        sys.stdout.flush()
 
-    host_remote = sys.argv[1]
-    if host_remote.endswith(".local") or host_remote.endswith(".local."):
-        print("An mDNS hostname was provided. Will resolve it to an IP address.")
-        host_remote = mdns_lookup(host_remote)
+    def handle_input(self, raw, discovered):
+        if raw == b"\x03":
+            raise KeyboardInterrupt
+        if raw in (b"\r", b"\n"):
+            stripped = self.buf.strip()
+            self.buf = ""
+            if stripped:
+                try:
+                    _, ip = discovered[int(stripped)]
+                    sys.stdout.write("\n")
+                    sys.stdout.flush()
+                    return ip
+                except (ValueError, IndexError):
+                    pass
+            return None
+        elif raw in (b"\x7f", b"\x08"):
+            self.buf = self.buf[:-1]
+        elif len(raw) == 1 and 32 <= raw[0] <= 126:
+            self.buf += raw.decode()
+        return None
 
-    set_remote(host_remote)
-    print(
-        f"Successfully set remote host to {Fore.LIGHTGREEN_EX}{host_remote}{Style.RESET_ALL}."
+
+# ============================================================
+# MDNSClient — socket lifecycle, query, resend, response parsing
+# ============================================================
+
+class MDNSClient:
+
+    PORT = 5353
+    MCAST4 = "224.0.0.251"
+    MCAST6 = "ff02::fb"
+    RESEND_INTERVAL = 1.0
+    _DNS_HDR = (
+        b"\x00\x00\x01\x00\x00\x01\x00\x00"
+        b"\x00\x00\x00\x00\x00\x00\x01\x00\x01"
     )
+
+    def __init__(self, hostname):
+        import dpkt
+        import select
+        import socket
+        import struct
+
+        self._dpkt = dpkt
+        self._select = select
+        self._socket = socket
+        self._struct = struct
+
+        self.hostname = hostname
+        self.socks = {}
+        self.groups = []
+        self._qpkts = {}
+        self.discovered = []
+
+        self._build_queries()
+        self._open()
+
+    # ---- packet helpers ----
+
+    def _mk(self, name, qtype):
+        d = self._dpkt.dns.DNS(self._DNS_HDR)
+        d.qd[0].name = name
+        d.qd[0].type = qtype
+        return d.pack()
+
+    @staticmethod
+    def _safe_sendto(sock, pkt, addr):
+        try:
+            sock.sendto(pkt, addr)
+        except OSError:
+            pass
+
+    def _send_pkt(self, pkt):
+        for s4, s6 in self.groups:
+            if s4:
+                self._safe_sendto(s4, pkt, (self.MCAST4, self.PORT))
+            if s6:
+                self._safe_sendto(s6, pkt, (self.MCAST6, self.PORT))
+
+    # ---- queries ----
+
+    def _build_queries(self):
+        self._qpkts[(self.hostname, self._dpkt.dns.DNS_A)] = self._mk(
+            self.hostname, self._dpkt.dns.DNS_A
+        )
+        self._qpkts[(self.hostname, self._dpkt.dns.DNS_AAAA)] = self._mk(
+            self.hostname, self._dpkt.dns.DNS_AAAA
+        )
+
+    def resend(self):
+        for pkt in self._qpkts.values():
+            self._send_pkt(pkt)
+
+    def add_query(self, name, qtype):
+        k = (name, qtype)
+        if k not in self._qpkts:
+            self._qpkts[k] = self._mk(name, qtype)
+            self._send_pkt(self._qpkts[k])
+
+    # ---- sockets ----
+
+    def _open(self):
+        sk = self._socket
+        st = self._struct
+        psutil = __import__("psutil")
+
+        ifaces = list(psutil.net_if_addrs().items())
+        max_w = max((len(n) for n, _ in ifaces), default=0)
+
+        print("Sending mDNS query packet to interfaces...")
+        for iface, addrs in ifaces:
+            name = iface.ljust(max_w)
+            if iface.startswith(("lo", "docker", "br-")):
+                tag = "loopback" if iface.startswith("lo") else "docker"
+                print(
+                    f"    - {name} : {Fore.LIGHTBLACK_EX}"
+                    f"Skipped ({tag} interface).{Style.RESET_ALL}"
+                )
+                continue
+
+            ip4 = ip6 = None
+            for a in addrs:
+                if a.family == sk.AF_INET:
+                    ip4 = a.address
+                elif (
+                    a.family == sk.AF_INET6
+                    and a.address.startswith("fe80")
+                ):
+                    ip6 = a.address
+
+            if ip4 is None and ip6 is None:
+                print(
+                    f"    - {name} : {Fore.LIGHTBLACK_EX}"
+                    f"Skipped (interface down).{Style.RESET_ALL}"
+                )
+                continue
+
+            s4 = s6 = None
+            ver = []
+
+            if ip4:
+                s4 = sk.socket(sk.AF_INET, sk.SOCK_DGRAM)
+                s4.setsockopt(sk.SOL_SOCKET, sk.SO_REUSEADDR, 1)
+                s4.setsockopt(sk.SOL_SOCKET, sk.SO_REUSEPORT, 1)
+                s4.bind(("0.0.0.0", self.PORT))
+                s4.setsockopt(
+                    sk.IPPROTO_IP,
+                    sk.IP_ADD_MEMBERSHIP,
+                    st.pack(
+                        "4s4s",
+                        sk.inet_aton(self.MCAST4),
+                        sk.inet_aton(ip4),
+                    ),
+                )
+                s4.setsockopt(sk.SOL_SOCKET, 25, iface.encode() + b"\0")
+                s4.setsockopt(
+                    sk.IPPROTO_IP,
+                    sk.IP_MULTICAST_IF,
+                    sk.inet_aton(ip4),
+                )
+                ver.append("IPv4")
+
+            if ip6:
+                idx = sk.if_nametoindex(iface)
+                s6 = sk.socket(sk.AF_INET6, sk.SOCK_DGRAM)
+                s6.setsockopt(sk.SOL_SOCKET, sk.SO_REUSEADDR, 1)
+                s6.setsockopt(sk.SOL_SOCKET, sk.SO_REUSEPORT, 1)
+                s6.bind(("::", self.PORT))
+                s6.setsockopt(
+                    sk.IPPROTO_IPV6,
+                    sk.IPV6_JOIN_GROUP,
+                    st.pack(
+                        "16si",
+                        sk.inet_pton(sk.AF_INET6, self.MCAST6),
+                        idx,
+                    ),
+                )
+                s6.setsockopt(sk.SOL_SOCKET, 25, iface.encode() + b"\0")
+                s6.setsockopt(
+                    sk.IPPROTO_IPV6,
+                    sk.IPV6_MULTICAST_IF,
+                    idx,
+                )
+                ver.append("IPv6")
+
+            for pkt in self._qpkts.values():
+                if s4:
+                    self._safe_sendto(s4, pkt, (self.MCAST4, self.PORT))
+                if s6:
+                    self._safe_sendto(s6, pkt, (self.MCAST6, self.PORT))
+
+            ver_str = " & ".join(ver)
+            print(
+                f"    - {name} : {Fore.LIGHTGREEN_EX}"
+                f"Query sent successfully ({ver_str}).{Style.RESET_ALL}"
+            )
+
+            if s4:
+                self.socks[s4] = iface
+            if s6:
+                self.socks[s6] = iface
+            self.groups.append((s4, s6))
+
+    # ---- receive + parse ----
+
+    def recv(self, timeout):
+        fds = list(self.socks.keys())
+        ready, _, _ = self._select.select(fds, [], [], timeout)
+        return ready
+
+    def process(self, sock):
+        m = sock.recvfrom(1024)
+        try:
+            dns = self._dpkt.dns.DNS(m[0])
+        except self._dpkt.UnpackError:
+            return
+        if not dns.an:
+            return
+
+        for rr in dns.an:
+            if rr.name != self.hostname:
+                continue
+
+            if rr.type == self._dpkt.dns.DNS_A:
+                ip = self._socket.inet_ntoa(rr.rdata)
+            elif rr.type == self._dpkt.dns.DNS_AAAA:
+                ip = self._socket.inet_ntop(self._socket.AF_INET6, rr.rdata)
+                if ip.startswith("fe80"):
+                    ip = f"{ip}%{self.socks[sock]}"
+            else:
+                continue
+
+            entry = (rr.name, ip)
+            if entry not in self.discovered:
+                self.discovered.append(entry)
+                sys.stdout.write(
+                    f"\r\033[K{Fore.LIGHTBLACK_EX}>>  "
+                    f"{Fore.LIGHTCYAN_EX}{len(self.discovered) - 1}."
+                    f"{Style.RESET_ALL} {rr.name}: "
+                    f"{Fore.LIGHTGREEN_EX}{ip}{Style.RESET_ALL}\n"
+                )
+
+
+# ============================================================
+# Application logic
+# ============================================================
+
+def _print_usage():
+    print("""
+Usage: set-remote <remote_host>
+  1. IPv4 / IPv6 address (e.g., 169.254.233.233)
+  2. IPv4 / IPv6 link-local address (e.g., fe80::...%eth0)
+  3. mDNS hostname (e.g., my-sentry.local)
+""")
 
 
 def mdns_lookup(hostname):
-    import dpkt
-    import psutil
-    import select
-    import socket
-    import struct
+    if not sys.stdin.isatty():
+        sys.exit("Error: set-remote requires an interactive terminal.")
 
-    mdns_udp_port = 5353
+    import time
 
-    dns_query = dpkt.dns.DNS(
-        b"\x00\x00\x01\x00\x00\x01\x00\x00" + b"\x00\x00\x00\x00\x00\x00\x01\x00\x01"
-    )
-    dns_query.qd[0].name = hostname
-    dns_query.qd[0].type = dpkt.dns.DNS_A
-    dns_query_packet4 = dns_query.pack()
-    dns_query.qd[0].type = dpkt.dns.DNS_AAAA
-    dns_query_packet6 = dns_query.pack()
+    client = MDNSClient(hostname)
 
-    socks = {}
-    sock_groups = []
+    with Terminal() as term:
+        fds = list(client.socks.keys()) + [sys.stdin]
+        last_resend = time.time()
+        term.draw(client.discovered)
 
-    print("Sending mDNS query packet to interfaces...")
-    for interface, addresses in psutil.net_if_addrs().items():
-        print(f"    - {interface}: ", end="")
-        if interface.startswith("lo") or interface.startswith("loopback"):
-            print(f"{Fore.LIGHTBLACK_EX}Skipped (loopback interface).{Style.RESET_ALL}")
-            continue
-        elif interface.startswith("docker") or interface.startswith("br-"):
-            print(f"{Fore.LIGHTBLACK_EX}Skipped (docker interface).{Style.RESET_ALL}")
-            continue
-
-        interface_ip4 = None
-        interface_ip6 = None
-
-        for addr in addresses:
-            if addr.family == socket.AF_INET:
-                interface_ip4 = addr.address
-            elif addr.family == socket.AF_INET6:
-                if addr.address.startswith("fe80"):
-                    interface_ip6 = addr.address
-
-        sock_group = [interface, None, None]
-
-        if interface_ip4 is not None:
-            multicast_group4 = "224.0.0.251"  # IPv4 mDNS multicast group
-
-            sock4 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock4.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock4.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-            sock4.bind(("0.0.0.0", mdns_udp_port))
-
-            # Join the IPv4 multicast group with the given interface
-            sock4.setsockopt(
-                socket.IPPROTO_IP,
-                socket.IP_ADD_MEMBERSHIP,
-                struct.pack(
-                    "4s4s",
-                    socket.inet_aton(multicast_group4),
-                    socket.inet_aton(interface_ip4),
-                ),
+        while True:
+            ready, _, _ = __import__("select").select(
+                fds, [], [], 0.05
             )
-            # Set the receiving interface
-            sock4.setsockopt(socket.SOL_SOCKET, 25, interface.encode("utf-8") + b"\0")
-            # Set the sending interface
-            sock4.setsockopt(
-                socket.IPPROTO_IP,
-                socket.IP_MULTICAST_IF,
-                socket.inet_aton(interface_ip4),
-            )
+            now = time.time()
 
-            sock4.sendto(dns_query_packet4, (multicast_group4, mdns_udp_port))
-            sock4.sendto(dns_query_packet6, (multicast_group4, mdns_udp_port))
+            if now - last_resend >= MDNSClient.RESEND_INTERVAL:
+                client.resend()
+                last_resend = now
 
-            sock_group[1] = sock4
-            socks[sock4] = interface
-
-        if interface_ip6 is not None:
-            multicast_group6 = "ff02::fb"  # IPv6 mDNS multicast group
-
-            sock6 = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-            sock6.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock6.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-            sock6.bind(("::", mdns_udp_port))
-
-            interface_index = socket.if_nametoindex(interface)
-            # Join the IPv6 multicast group with the given interface
-            sock6.setsockopt(
-                socket.IPPROTO_IPV6,
-                socket.IPV6_JOIN_GROUP,
-                struct.pack(
-                    "16si",
-                    socket.inet_pton(socket.AF_INET6, multicast_group6),
-                    interface_index,
-                ),
-            )
-            # Set the receiving interface
-            sock6.setsockopt(socket.SOL_SOCKET, 25, interface.encode("utf-8") + b"\0")
-            # Set the sending interface
-            sock6.setsockopt(
-                socket.IPPROTO_IPV6,
-                socket.IPV6_MULTICAST_IF,
-                interface_index,
-            )
-
-            sock6.sendto(dns_query_packet6, (multicast_group6, mdns_udp_port))
-
-            sock_group[2] = sock6
-            socks[sock6] = interface
-
-        if interface_ip4 is not None and interface_ip6 is not None:
-            ip_version = "IPv4 & IPv6"
-        elif interface_ip4 is not None:
-            ip_version = "IPv4"
-        elif interface_ip6 is not None:
-            ip_version = "IPv6"
-        else:
-            print(f"{Fore.LIGHTBLACK_EX}Skipped (interface down).{Style.RESET_ALL}")
-            continue
-
-        print(
-            f"{Fore.LIGHTGREEN_EX}Query sent successfully ({ip_version}).{Style.RESET_ALL}"
-        )
-        sock_groups.append(sock_group)
-
-    discovered_list = []
-
-    while True:
-        ready_socks, _, _ = select.select(socks.keys(), [], [], 1.0)
-
-        if not ready_socks:
-            index = input(
-                "Enter the index to select a address, or press Enter to search again: "
-                if discovered_list
-                else "No addresses found. Press Enter to search again or Ctrl+C to exit: "
-            )
-            if index:
-                index = int(index)
-                _, ip = discovered_list[index]
-                return ip
-            else:
-                print("\033[A\r\033[KRe-sending mDNS query packet...")
-                for interface, sock4, sock6 in sock_groups:
-                    if sock4 is not None:
-                        sock4.sendto(
-                            dns_query_packet4, (multicast_group4, mdns_udp_port)
-                        )
-                        sock4.sendto(
-                            dns_query_packet6, (multicast_group4, mdns_udp_port)
-                        )
-                    if sock6 is not None:
-                        sock6.sendto(
-                            dns_query_packet6, (multicast_group6, mdns_udp_port)
-                        )
-
-                    if sock4 is not None and sock6 is not None:
-                        ip_version = "IPv4 & IPv6"
-                    elif sock4 is not None:
-                        ip_version = "IPv4"
-                    elif sock6 is not None:
-                        ip_version = "IPv6"
-                    print(
-                        f"    - {interface}: "
-                        f"{Fore.LIGHTGREEN_EX}Query re-sent successfully ({ip_version}).{Style.RESET_ALL}"
-                    )
-
-            continue
-
-        for sock in ready_socks:
-            m = sock.recvfrom(1024)
-
-            try:
-                dns = dpkt.dns.DNS(m[0])
-            except dpkt.UnpackError:
-                continue
-
-            if len(dns.an) == 0:
-                continue
-
-            host = dns.an[0].name
-            if host != hostname:
-                continue
-            if dns.an[0].type == dpkt.dns.DNS_A:
-                ip = socket.inet_ntoa(dns.an[0].rdata)
-            elif dns.an[0].type == dpkt.dns.DNS_AAAA:
-                ip = socket.inet_ntop(socket.AF_INET6, dns.an[0].rdata)
-                if ip.startswith("fe80"):
-                    interface = socks[sock]
-                    ip = f"{ip}%{interface}"
-            else:
-                continue
-
-            if (host, ip) not in discovered_list:
-                print(
-                    f"{Fore.LIGHTBLACK_EX}>>  {Fore.LIGHTCYAN_EX}{len(discovered_list)}.{Style.RESET_ALL} {host}: {Fore.LIGHTGREEN_EX}{ip}{Style.RESET_ALL}"
+            if sys.stdin in ready:
+                result = term.handle_input(
+                    sys.stdin.buffer.raw.read(1), client.discovered
                 )
-                discovered_list.append((host, ip))
+                if result:
+                    return result
+                continue
+
+            for sock in ready:
+                if sock is not sys.stdin:
+                    client.process(sock)
+
+            term.draw(client.discovered)
 
 
 def set_remote(address):
     ssh_path = os.path.join(os.getenv("HOME"), ".ssh", "config")
     try:
-        # judge input type
-        if address.find(":") != -1:
-            ipv6 = True
-        else:
-            ipv6 = False
-
-        # find single '%' in host_remote and replace it with double '%%'
-        address = re.sub(r"(?<!%)%(?!%)", "%%", address)
-
-        # Update the HostName for the 'remote' host entry in the SSH config
-        with open(ssh_path, "r") as file:
-            config = file.read()
-        config, update_count = re.subn(
-            r"Host remote\n    HostName [^\n]+",
-            f"Host remote\n    HostName {address}",
-            config,
-        )
-        if update_count == 0:
-            print("Error: Cannot find any place to modify HostName in SSH config.")
-            sys.exit(1)
-
-        # Update the AddressFamily for the 'remote' host entry in the SSH config
-        config, update_count = re.subn(
-            r"AddressFamily inet6?",
-            f"AddressFamily inet{'6' if ipv6 else ''}",
-            config,
-        )
-        if update_count == 0:
-            print("Error: Cannot find any place to modify AddressFamily in SSH config.")
-            sys.exit(1)
-
-        with open(ssh_path, "w") as file:
-            file.write(config)
-
+        config = open(ssh_path).read()
     except FileNotFoundError:
-        print("Error: SSH config file not found.")
-        sys.exit(1)
+        sys.exit("Error: SSH config file not found.")
+
+    ipv6 = ":" in address
+    address = re.sub(r"(?<!%)%(?!%)", "%%", address)
+
+    config, n1 = re.subn(
+        r"Host remote\n    HostName [^\n]+",
+        f"Host remote\n    HostName {address}",
+        config,
+    )
+    config, n2 = re.subn(
+        r"(Host remote\n(?:(?!Host ).+\n)*)    AddressFamily inet6?",
+        rf"\1    AddressFamily {'inet6' if ipv6 else 'inet'}",
+        config,
+    )
+
+    if not n1 or not n2:
+        sys.exit("Error: Cannot find expected entries in SSH config.")
+
+    with open(ssh_path, "w") as f:
+        f.write(config)
 
 
 if __name__ == "__main__":
     try:
-        main()
+        if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):
+            _print_usage()
+            sys.exit(1)
+
+        host = sys.argv[1]
+        if host.endswith(".local") or host.endswith(".local."):
+            print(
+                "An mDNS hostname was provided."
+                " Will resolve it to an IP address."
+            )
+            host = mdns_lookup(host)
+
+        set_remote(host)
+        print(
+            f"Successfully set remote host to "
+            f"{Fore.LIGHTGREEN_EX}{host}{Style.RESET_ALL}."
+        )
     except KeyboardInterrupt:
         sys.exit(1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 脚本重构与功能改进

### 主要改动

本PR对 `.script/set-remote` 脚本进行了全面重构，将单块式设计拆分为结构化组件，提升了代码可维护性和功能完整性。

### 新增核心类与函数

**Terminal 类**
- 实现终端原始模式管理，支持实时输入捕获和无回显的交互式按键处理
- 内置动画旋转器（spinner），为用户提供视觉反馈
- 处理用户输入（退出、回车、退格、数字选择等）
- 替代了之前的 `input()` 函数式选择流程

**MDNSClient 类**
- 构建和管理 DNS 查询数据包（A 记录和 AAAA 记录）
- 为每个网络接口配置独立的 IPv4/IPv6 UDP 多播套接字
- 实现定时查询重发机制（1秒间隔）
- 解析 DNS 响应记录，包括对 IPv6 链路本地地址的区域ID处理（通过接口名称映射）
- 网络接口过滤：跳过环回、Docker 和网桥接口

**_print_usage() 函数**
- 提供清晰的使用说明，支持 IPv4/IPv6 地址和 mDNS 主机名三种输入格式

### 行为变更

**mdns_lookup() 函数**
- 重写核心逻辑，采用事件轮询驱动的架构
- 集成 Terminal 和 MDNSClient 实现交互式地址选择
- 支持终端检测和定时查询重发

**set_remote() 函数**
- 简化实现，直接读写 `~/.ssh/config` 文件
- 通过正则表达式更新 `HostName` 和 `AddressFamily` 配置
- 增强错误处理，当找不到预期配置项时主动退出

**脚本入口 (__main__)**
- 新增命令行参数验证（必须恰好一个参数）
- 集中处理帮助选项（-h/--help）
- 优化执行流程：先验证参数 → 再解析 .local 域名 → 最后更新远程配置

### 技术指标
- 代码行数：+346/-234
- 代码复杂度：高（新增两个重量级类，涉及网络编程和终端控制）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->