### PR TITLE
fix(dockerfile): Avoid autoremove removing runtime deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libatlas-base-dev \
     libsuitesparse-dev \
     libceres-dev \
-    ros-$ROS_DISTRO-rviz2 \
-    ros-$ROS_DISTRO-foxglove-bridge \
+    ros-$ROS_DISTRO-rviz2 ros-$ROS_DISTRO-foxglove-bridge \
     ros-$ROS_DISTRO-pcl-ros ros-$ROS_DISTRO-pcl-conversions ros-$ROS_DISTRO-pcl-msgs \
     ros-$ROS_DISTRO-navigation2 ros-$ROS_DISTRO-nav2-msgs \
     lua5.4 liblua5.4-0 liblua5.4-dev && \
-    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 
@@ -55,7 +54,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
             > /etc/apt/sources.list.d/intel-openvino.list && \
         apt-get update && \
         apt-get install -y --no-install-recommends openvino-2025.2.0 && \
-        apt-get autoremove -y && apt-get clean && \
+        apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/*; \
     else \
         echo "Skipping OpenVINO install on ${TARGETARCH}"; \
@@ -75,7 +74,7 @@ RUN git clone https://github.com/Livox-SDK/Livox-SDK2.git && \
 RUN --mount=type=bind,target=/rmcs_ws/src,source=rmcs_ws/src,readonly \
     apt-get update && \
     rosdep install --from-paths /rmcs_ws/src --ignore-src -r -y && \
-    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Build Unison from source because upstream does not ship arm64 release binaries
@@ -110,13 +109,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-colorama python3-dpkt && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 50 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 50 && \
-    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Install Node.js 24 LTS (required by agent CLIs)
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Install llvm-toolchain
@@ -140,7 +139,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-${LLVM_VERSION} 50 && \
     update-alternatives --install /usr/bin/llvm-ranlib llvm-ranlib /usr/bin/llvm-ranlib-${LLVM_VERSION} 50 && \
     update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-${LLVM_VERSION} 50 && \
-    apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Generate/load ssh key and setup unison
 RUN --mount=type=bind,target=/tmp/.ssh,source=.ssh,readonly=false \
@@ -223,7 +222,7 @@ RUN apt-get update && \
         "binutils-${cross_pkg_triplet}" && \
     update-alternatives --install "/usr/bin/${cross_triplet}-gcc" "${cross_triplet}-gcc" "/usr/bin/${cross_triplet}-gcc-14" 50 && \
     update-alternatives --install "/usr/bin/${cross_triplet}-g++" "${cross_triplet}-g++" "/usr/bin/${cross_triplet}-g++-14" 50 && \
-    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 RUN mkdir -p /opt/sysroots && \
@@ -266,7 +265,7 @@ FROM rmcs-base AS rmcs-runtime
 # Install runtime tools
 RUN apt-get update && \
     apt-get install -y --no-install-recommends tini openssh-server avahi-daemon orphan-sysvinit-scripts && \
-    apt-get autoremove -y && apt-get clean && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
     echo 'Port 2022' >> /etc/ssh/sshd_config && \
     echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config && \


### PR DESCRIPTION
修复 Dockerfile 中多处安装步骤在完成后执行 apt-get autoremove -y 的问题。该清理行为会在镜像构建过程中误删由其他包间接拉起的运行时依赖，导致后续环境缺少实际需要的库。此次修改将常规安装层中的 autoremove 调整为仅执行缓存清理，保留显式临时构建依赖的定向卸载逻辑，从而避免运行时依赖被错误移除