### PR TITLE
feat(docker): Install Hik MVS USB3 camera SDK with amd64/arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,111 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
+# Install Hik MVS runtime SDK and its runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libbz2-1.0 \
+    libgcc-s1 \
+    libstdc++6 \
+    libudev1 \
+    libusb-1.0-0 \
+    zlib1g && \
+    apt-get autoremove -y && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && \
+    set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) arch_tag=x86_64; arch_dir=64 ;; \
+        arm64) arch_tag=aarch64; arch_dir=aarch64 ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    download_url="https://github.com/Alliance-Algorithm/hik-mvs/releases/latest/download/mvs-sdk-${arch_tag}.tar.gz"; \
+    mkdir -p /tmp/mvs-src \
+        "/opt/mvs-usb3-core/lib/${arch_dir}" \
+        /opt/mvs-usb3-core/lib/cmake/MVSUSB3Core \
+        /opt/mvs-usb3-core/include \
+        /usr/local/bin; \
+    curl -fsSL -o /tmp/mvs.tar.gz "${download_url}"; \
+    tar -xzf /tmp/mvs.tar.gz -C /tmp/mvs-src; \
+    cp -a "/tmp/mvs-src/lib/${arch_dir}/." "/opt/mvs-usb3-core/lib/${arch_dir}/"; \
+    cp -a /tmp/mvs-src/include/. /opt/mvs-usb3-core/include/; \
+    rm -f "/opt/mvs-usb3-core/lib/${arch_dir}/libusb-1.0.so.0"; \
+    case "${TARGETARCH}" in \
+        amd64) \
+            rm -f \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libCLAllSerial_gcc485_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libCLProtocol_gcc485_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libCLSerCOM.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libCLSerHvc.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libGCBase_gcc485_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libGenCP_gcc485_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/liblog4cpp_gcc485_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libLog_gcc485_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCameraControlWrapper.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCameraControlWrapper.so.4.7.0.1" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCamLVision.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCamLVision.so.4.7.0.3" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMVGigEVisionSDK.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMVGigEVisionSDK.so.4.7.1.1" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMVFGControl.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvProducerVIR.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvLCProducer.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/MvLCProducer.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/MvProducerGEV.cti" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/MvFGProducerCML.cti" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/MvFGProducerCXP.cti" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/MvFGProducerGEV.cti" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/MvFGProducerXoF.cti"; \
+            ;; \
+        arm64) \
+            rm -f \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libCLAllSerial_gcc494_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libCLProtocol_gcc494_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libCLSerCOM.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libGCBase_gcc494_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libGenCP_gcc494_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/liblog4cpp_gcc494_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libLog_gcc494_v3_0.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCameraControlWrapper.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCameraControlWrapper.so.4.7.0.1" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCamLVision.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMvCamLVision.so.4.7.0.3" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMVGigEVisionSDK.so" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/libMVGigEVisionSDK.so.4.7.1.1" \
+                "/opt/mvs-usb3-core/lib/${arch_dir}/MvProducerGEV.cti"; \
+            ;; \
+        *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    rm -rf /var/lib/apt/lists/* /tmp/mvs-src /tmp/mvs.tar.gz; \
+    cmake_dir=/opt/mvs-usb3-core/lib/cmake/MVSUSB3Core; \
+    <<EOF cat > "${cmake_dir}/MVSUSB3CoreConfig.cmake"
+get_filename_component(MVSUSB3Core_ROOT "\${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+set(MVSUSB3Core_INCLUDE_DIR "\${MVSUSB3Core_ROOT}/include")
+set(MVSUSB3Core_INCLUDE_DIRS "\${MVSUSB3Core_INCLUDE_DIR}")
+set(MVSUSB3Core_LIBRARY_DIR "\${MVSUSB3Core_ROOT}/lib/${arch_dir}")
+set(MVSUSB3Core_LIBRARY "\${MVSUSB3Core_LIBRARY_DIR}/libMvCameraControl.so")
+set(MVSUSB3Core_LIBRARIES "\${MVSUSB3Core_LIBRARY}")
+
+if(NOT EXISTS "\${MVSUSB3Core_INCLUDE_DIR}/MvCameraControl.h")
+  set(MVSUSB3Core_FOUND FALSE)
+  message(FATAL_ERROR "MVSUSB3Core headers not found under \${MVSUSB3Core_INCLUDE_DIR}")
+endif()
+
+if(NOT EXISTS "\${MVSUSB3Core_LIBRARY}")
+  set(MVSUSB3Core_FOUND FALSE)
+  message(FATAL_ERROR "MVSUSB3Core library libMvCameraControl.so not found under \${MVSUSB3Core_LIBRARY_DIR}")
+endif()
+
+if(NOT TARGET MVSUSB3Core::MVSUSB3Core)
+  add_library(MVSUSB3Core::MVSUSB3Core SHARED IMPORTED GLOBAL)
+  set_target_properties(MVSUSB3Core::MVSUSB3Core PROPERTIES
+    IMPORTED_LOCATION "\${MVSUSB3Core_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "\${MVSUSB3Core_INCLUDE_DIR}"
+  )
+endif()
+
+set(MVSUSB3Core_FOUND TRUE)
+EOF
+
 
 # Install openvino runtime
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \


### PR DESCRIPTION
Download and extract the MVS SDK into /opt/mvs-usb3-core/, strip non-USB3 drivers (GigE, CameraLink, MVFG, etc.) matching the upstream policy, and generate a CMake config for find_package integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 功能特性

在 Dockerfile 的 `rmcs-base` 构建阶段新增一个 RUN 指令，用于安装海康威视 MVS USB3 摄像机 SDK。该步骤包含以下操作：

### 依赖库安装
- 安装运行时依赖：`libbz2-1.0`、`libgcc-s1`、`libstdc++6`、`libudev1`、`libusb-1.0-0`、`zlib1g`

### SDK 下载与提取
- 根据构建目标架构（`TARGETARCH`）动态选择对应的 SDK 版本：
  - `amd64` → 下载 `mvs-sdk-x86_64.tar.gz`
  - `arm64` → 下载 `mvs-sdk-aarch64.tar.gz`
- 从 GitHub `Alliance-Algorithm/hik-mvs` 仓库的 release 页面下载最新版本
- 将 SDK 解压至 `/opt/mvs-usb3-core` 目录

### 驱动库清理
- 删除系统提供的 `libusb-1.0.so.0`（避免冲突）
- 移除非 USB3 相关驱动库，包括 GigE、CameraLink、MVFG 等驱动对应的库文件：
  - **amd64**：删除 22 个库文件（libCLAllSerial_gcc485、libMVGigEVisionSDK、libMVFGControl 等）
  - **arm64**：删除 13 个库文件（同名库的 gcc494 版本及部分 MVFG 相关库）

### CMake 集成
- 在 `/opt/mvs-usb3-core/lib/cmake/MVSUSB3Core` 目录生成 `MVSUSB3CoreConfig.cmake` 配置文件
- 配置文件设置以下 CMake 变量：
  - `MVSUSB3Core_INCLUDE_DIR`、`MVSUSB3Core_LIBRARY_DIR`、`MVSUSB3Core_LIBRARY` 等
  - 创建 CMake 导入目标 `MVSUSB3Core::MVSUSB3Core`，配置 `IMPORTED_LOCATION` 和 `INTERFACE_INCLUDE_DIRECTORIES`
  - 添加校验机制：若 `MvCameraControl.h` 头文件或 `libMvCameraControl.so` 库文件不存在，则触发 `FATAL_ERROR`

## 代码变更

- 文件：Dockerfile
- 新增行数：105
- 修改类型：新增 RUN 阶段指令

<!-- end of auto-generated comment: release notes by coderabbit.ai -->