### PR TITLE
feat: Rebuild steering-infantry from climbable-infantry base

### DIFF
--- a/rmcs_ws/src/rmcs_bringup/config/steering-infantry.yaml
+++ b/rmcs_ws/src/rmcs_bringup/config/steering-infantry.yaml
@@ -2,18 +2,18 @@ rmcs_executor:
   ros__parameters:
     update_rate: 1000.0
     components:
-      - rmcs_core::hardware::SteeringInfantry -> steeringInfantry_hardware
+      - rmcs_core::hardware::SteeringInfantry -> Infantry_hardware
 
       - rmcs_core::referee::Status -> referee_status
-      - rmcs_core::referee::Command -> referee_command
-
       - rmcs_core::referee::command::Interaction -> referee_interaction
       - rmcs_core::referee::command::interaction::Ui -> referee_ui
-      # - rmcs_core::referee::app::ui::Infantry -> referee_ui_infantry
+      - rmcs_core::referee::app::ui::Infantry -> referee_ui_infantry
+      - rmcs_core::referee::Command -> referee_command
 
       - rmcs_core::controller::gimbal::SimpleGimbalController -> gimbal_controller
-      - rmcs_core::controller::pid::ErrorPidController -> yaw_angle_pid_controller
       - rmcs_core::controller::pid::ErrorPidController -> pitch_angle_pid_controller
+      - rmcs_core::controller::pid::ErrorPidController -> yaw_angle_pid_controller
+      - rmcs_core::controller::pid::PidController -> yaw_velocity_pid_controller
 
       - rmcs_core::controller::shooting::FrictionWheelController -> friction_wheel_controller
       - rmcs_core::controller::shooting::HeatController -> heat_controller
@@ -26,37 +26,47 @@ rmcs_executor:
       - rmcs_core::controller::chassis::ChassisPowerController -> chassis_power_controller
       - rmcs_core::controller::chassis::SteeringWheelController -> steering_wheel_controller
 
-steeringInfantry_hardware:
+Infantry_hardware:
   ros__parameters:
-    board_serial_top_board: "(TODO)"
-    board_serial_bottom_board: "(TODO)"
-    yaw_motor_zero_point: 32285
-    pitch_motor_zero_point: 6321
-    left_front_zero_point: 7848
-    left_back_zero_point: 5770
-    right_back_zero_point: 2380
-    right_front_zero_point: 1705
+    board_serial_top_board: "AF-B4E5-CE0E-4342-FF2C-F9E2-DE47-2D85-9B75"
+    board_serial_bottom_board: "AF-EEF5-24BA-6675-F1B1-C797-50AF-869C-870E"
+    yaw_motor_zero_point: 20993
+    pitch_motor_zero_point: 18874
+    left_front_zero_point: 1695
+    right_front_zero_point: 5068
+    left_back_zero_point: 7870
+    right_back_zero_point: 3141
+
 
 gimbal_controller:
   ros__parameters:
-    upper_limit: -0.39518
-    lower_limit: 0.36
-
-yaw_angle_pid_controller:
-  ros__parameters:
-    measurement: /gimbal/yaw/control_angle_error
-    control: /gimbal/yaw/control_velocity
-    kp: 16.0
-    ki: 0.0
-    kd: 0.0
+    upper_limit: -0.54
+    lower_limit: 0.274
 
 pitch_angle_pid_controller:
   ros__parameters:
     measurement: /gimbal/pitch/control_angle_error
     control: /gimbal/pitch/control_velocity
-    kp: 10.00
+    kp: 15.0
     ki: 0.0
-    kd: 0.0
+    kd: 1.5
+
+yaw_angle_pid_controller:
+  ros__parameters:
+    measurement: /gimbal/yaw/control_angle_error
+    control: /gimbal/yaw/control_velocity
+    kp: 20.0
+    ki: 0.0
+    kd: 0.9
+
+yaw_velocity_pid_controller:
+  ros__parameters:
+    measurement: /gimbal/yaw/velocity_imu
+    setpoint: /gimbal/yaw/control_velocity
+    control: /gimbal/yaw/control_torque
+    kp: 2.5
+    ki: 0.00
+    kd: 0.6
 
 friction_wheel_controller:
   ros__parameters:
@@ -64,9 +74,9 @@ friction_wheel_controller:
       - /gimbal/left_friction
       - /gimbal/right_friction
     friction_velocities:
-      - 600.0
-      - 600.0
-    friction_soft_start_stop_time: 1.0
+      - 590.0
+      - 590.0
+    friction_soft_start_stop_time: 0.3
 
 heat_controller:
   ros__parameters:
@@ -75,8 +85,8 @@ heat_controller:
 
 bullet_feeder_controller:
   ros__parameters:
-    bullets_per_feeder_turn: 10.0
-    shot_frequency: 24.0
+    bullets_per_feeder_turn: 9.0
+    shot_frequency: 27.0
     safe_shot_frequency: 10.0
     eject_frequency: 15.0
     eject_time: 0.15
@@ -86,8 +96,8 @@ bullet_feeder_controller:
 
 shooting_recorder:
   ros__parameters:
-    friction_wheel_count: 4
-    log_mode: 2 # 1: trigger, 2: timing
+    friction_wheel_count: 2
+    log_mode: 1
 
 left_friction_velocity_pid_controller:
   ros__parameters:
@@ -112,15 +122,15 @@ bullet_feeder_velocity_pid_controller:
     measurement: /gimbal/bullet_feeder/velocity
     setpoint: /gimbal/bullet_feeder/control_velocity
     control: /gimbal/bullet_feeder/control_torque
-    kp: 0.283
+    kp: 0.7
     ki: 0.0
     kd: 0.0
 
 steering_wheel_controller:
   ros__parameters:
-    mess: 19.0
-    moment_of_inertia: 1.0
-    vehicle_radius: 0.24678
+    mess: 22.0
+    moment_of_inertia: 1.08
+    vehicle_radius: 0.28284271247462
     wheel_radius: 0.055
     friction_coefficient: 0.6
     k1: 2.958580e+00

--- a/rmcs_ws/src/rmcs_core/CMakeLists.txt
+++ b/rmcs_ws/src/rmcs_core/CMakeLists.txt
@@ -17,8 +17,8 @@ include(FetchContent)
 set(BUILD_STATIC_LIBRMCS ON CACHE BOOL "Build static librmcs SDK" FORCE)
 FetchContent_Declare(
   librmcs
-  URL https://github.com/Alliance-Algorithm/librmcs/releases/download/v3.2.0b0/librmcs-sdk-src-3.2.0-beta.0.zip
-  URL_HASH SHA256=391b642a31473fdb639573912e0fc6266c3819d787b91440310cd1025af1dc3c
+  URL https://github.com/Alliance-Algorithm/librmcs/releases/download/v3.2.0/librmcs-sdk-src-3.2.0.zip
+  URL_HASH SHA256=f81c3af7fbcf35727a8a7586200db8e9bf668ee0f448529de4bfd3eb7c36ed6f
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(librmcs)

--- a/rmcs_ws/src/rmcs_core/src/hardware/steering-infantry.cpp
+++ b/rmcs_ws/src/rmcs_core/src/hardware/steering-infantry.cpp
@@ -1,13 +1,15 @@
+#include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <span>
 #include <string_view>
 #include <tuple>
-#include <utility>
 
 #include <eigen3/Eigen/Dense>
 #include <librmcs/agent/c_board.hpp>
+#include <librmcs/agent/rmcs_board_lite.hpp>
 #include <librmcs/data/datas.hpp>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
@@ -42,7 +44,6 @@ public:
               create_partner_component<SteeringInfantryCommand>(
                   get_component_name() + "_command", *this)) {
         register_output("/tf", tf_);
-
         gimbal_calibrate_subscription_ = create_subscription<std_msgs::msg::Int32>(
             "/gimbal/calibrate", rclcpp::QoS{0}, [this](std_msgs::msg::Int32::UniquePtr&& msg) {
                 gimbal_calibrate_subscription_callback(std::move(msg));
@@ -54,7 +55,6 @@ public:
 
         top_board_ = std::make_unique<TopBoard>(
             *this, *command_component_, get_parameter("board_serial_top_board").as_string());
-
         bottom_board_ = std::make_unique<BottomBoard>(
             *this, *command_component_, get_parameter("board_serial_bottom_board").as_string());
 
@@ -75,7 +75,6 @@ public:
     }
 
     void command_update() {
-
         top_board_->command_update();
         bottom_board_->command_update();
     }
@@ -93,70 +92,62 @@ private:
     void steers_calibrate_subscription_callback(std_msgs::msg::Int32::UniquePtr) {
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New left front offset: %d",
-            bottom_board_->chassis_steer_motors_[0].calibrate_zero_point());
+            bottom_board_->chassis_front_steering_motors_[0].calibrate_zero_point());
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New left back offset: %d",
-            bottom_board_->chassis_steer_motors_[1].calibrate_zero_point());
+            bottom_board_->chassis_back_steering_motors_[0].calibrate_zero_point());
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New right back offset: %d",
-            bottom_board_->chassis_steer_motors_[2].calibrate_zero_point());
+            bottom_board_->chassis_back_steering_motors_[1].calibrate_zero_point());
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New right front offset: %d",
-            bottom_board_->chassis_steer_motors_[3].calibrate_zero_point());
+            bottom_board_->chassis_front_steering_motors_[1].calibrate_zero_point());
     }
+
     class SteeringInfantryCommand : public rmcs_executor::Component {
     public:
-        explicit SteeringInfantryCommand(SteeringInfantry& steering_infantry)
-            : steering_infantry(steering_infantry) {}
+        explicit SteeringInfantryCommand(SteeringInfantry& infantry_)
+            : infantry_(infantry_) {}
 
-        void update() override { steering_infantry.command_update(); }
+        void update() override { infantry_.command_update(); }
 
-        SteeringInfantry& steering_infantry;
+        SteeringInfantry& infantry_;
     };
+    std::shared_ptr<SteeringInfantryCommand> command_component_;
 
-    class TopBoard final : private librmcs::agent::CBoard {
+    class TopBoard final : private librmcs::agent::RmcsBoardLite {
     public:
         friend class SteeringInfantry;
         explicit TopBoard(
-            SteeringInfantry& steering_infantry, SteeringInfantryCommand& steering_infantry_command,
-            std::string_view board_serial = {})
-            : librmcs::agent::CBoard(board_serial)
-            , tf_(steering_infantry.tf_)
-            , bmi088_(1000, 0.2, 0.0)
-            , gimbal_pitch_motor_(steering_infantry, steering_infantry_command, "/gimbal/pitch")
+            SteeringInfantry& climbable_infantry,
+            SteeringInfantryCommand& climbable_infantry_command, std::string_view board_serial = {})
+            : librmcs::agent::RmcsBoardLite(board_serial, {true})
+            , tf_(climbable_infantry.tf_)
+            , imu_(1000, 0.2, 0.0)
+            , gimbal_pitch_motor_(climbable_infantry, climbable_infantry_command, "/gimbal/pitch")
             , gimbal_left_friction_(
-                  steering_infantry, steering_infantry_command, "/gimbal/left_friction")
+                  climbable_infantry, climbable_infantry_command, "/gimbal/left_friction")
             , gimbal_right_friction_(
-                  steering_infantry, steering_infantry_command, "/gimbal/right_friction") {
-            gimbal_pitch_motor_.configure(
-                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}.set_encoder_zero_point(
-                    static_cast<int>(
-                        steering_infantry.get_parameter("pitch_motor_zero_point").as_int())));
+                  climbable_infantry, climbable_infantry_command, "/gimbal/right_friction") {
 
+            gimbal_pitch_motor_.configure(
+                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("pitch_motor_zero_point").as_int()))
+                    .enable_multi_turn_angle());
             gimbal_left_friction_.configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kM3508}.set_reduction_ratio(1.));
             gimbal_right_friction_.configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
                     .set_reduction_ratio(1.)
                     .set_reversed());
-
-            steering_infantry.register_output(
-                "/gimbal/yaw/velocity_imu", gimbal_yaw_velocity_bmi088_);
-            steering_infantry.register_output(
-                "/gimbal/pitch/velocity_imu", gimbal_pitch_velocity_bmi088_);
-
-            bmi088_.set_coordinate_mapping([](double x, double y, double z) {
-                // Get the mapping with the following code.
-                // The rotation angle must be an exact multiple of 90 degrees, otherwise
-                // use a matrix.
-
-                // Eigen::AngleAxisd pitch_link_to_bmi088_link{
-                //     std::numbers::pi / 2, Eigen::Vector3d::UnitZ()};
-                // Eigen::Vector3d mapping = pitch_link_to_bmi088_link * Eigen::Vector3d{1, 2, 3};
-                // std::cout << mapping << std::endl;
-
-                return std::make_tuple(x, y, z);
-            });
+            climbable_infantry.register_output(
+                "/gimbal/yaw/velocity_imu", gimbal_yaw_velocity_imu_);
+            climbable_infantry.register_output(
+                "/gimbal/pitch/velocity_imu", gimbal_pitch_velocity_imu_);
+            imu_.set_coordinate_mapping(
+                [](double x, double y, double z) { return std::make_tuple(x, y, z); });
         }
 
         TopBoard(const TopBoard&) = delete;
@@ -164,18 +155,17 @@ private:
         TopBoard(TopBoard&&) = delete;
         TopBoard& operator=(TopBoard&&) = delete;
 
-        ~TopBoard() override = default;
+        ~TopBoard() final = default;
 
         void update() {
-            bmi088_.update_status();
-            const Eigen::Quaterniond gimbal_bmi088_pose{
-                bmi088_.q0(), bmi088_.q1(), bmi088_.q2(), bmi088_.q3()};
+            imu_.update_status();
+            const Eigen::Quaterniond gimbal_imu_pose{imu_.q0(), imu_.q1(), imu_.q2(), imu_.q3()};
 
             tf_->set_transform<rmcs_description::PitchLink, rmcs_description::OdomImu>(
-                gimbal_bmi088_pose.conjugate());
+                gimbal_imu_pose.conjugate());
 
-            *gimbal_yaw_velocity_bmi088_ = bmi088_.gz();
-            *gimbal_pitch_velocity_bmi088_ = bmi088_.gy();
+            *gimbal_yaw_velocity_imu_ = imu_.gz();
+            *gimbal_pitch_velocity_imu_ = imu_.gy();
 
             gimbal_pitch_motor_.update_status();
             gimbal_left_friction_.update_status();
@@ -192,19 +182,17 @@ private:
                 .can_id = 0x200,
                 .can_data =
                     device::CanPacket8{
-                        device::CanPacket8::PaddingQuarter{},
-                        device::CanPacket8::PaddingQuarter{},
-                        gimbal_left_friction_.generate_command(),
                         gimbal_right_friction_.generate_command(),
+                        gimbal_left_friction_.generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
                     }
                         .as_bytes(),
             });
 
             builder.can2_transmit({
-                .can_id = 0x142,
-                .can_data = gimbal_pitch_motor_
-                                .generate_velocity_command(gimbal_pitch_motor_.control_velocity())
-                                .as_bytes(),
+                .can_id = 0x143,
+                .can_data = gimbal_pitch_motor_.generate_velocity_command().as_bytes(),
             });
         }
 
@@ -213,283 +201,20 @@ private:
             if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
                 return;
             auto can_id = data.can_id;
-            if (can_id == 0x203) {
-                gimbal_left_friction_.store_status(data.can_data);
-            } else if (can_id == 0x204) {
+            if (can_id == 0x201) {
                 gimbal_right_friction_.store_status(data.can_data);
+            } else if (can_id == 0x202) {
+                gimbal_left_friction_.store_status(data.can_data);
             }
         }
+
         void can2_receive_callback(const librmcs::data::CanDataView& data) override {
             if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
                 return;
             auto can_id = data.can_id;
-            if (can_id == 0x142)
+            if (can_id == 0x143) {
                 gimbal_pitch_motor_.store_status(data.can_data);
-        }
-        void accelerometer_receive_callback(
-            const librmcs::data::AccelerometerDataView& data) override {
-            bmi088_.store_accelerometer_status(data.x, data.y, data.z);
-        }
-        void gyroscope_receive_callback(const librmcs::data::GyroscopeDataView& data) override {
-            bmi088_.store_gyroscope_status(data.x, data.y, data.z);
-        }
-        OutputInterface<rmcs_description::Tf>& tf_;
-
-        OutputInterface<double> gimbal_yaw_velocity_bmi088_;
-        OutputInterface<double> gimbal_pitch_velocity_bmi088_;
-
-        device::Bmi088 bmi088_;
-        device::LkMotor gimbal_pitch_motor_;
-        device::DjiMotor gimbal_left_friction_;
-        device::DjiMotor gimbal_right_friction_;
-    };
-
-    class BottomBoard final : private librmcs::agent::CBoard {
-    public:
-        friend class SteeringInfantry;
-
-        explicit BottomBoard(
-            SteeringInfantry& steering_infantry, SteeringInfantryCommand& steering_infantry_command,
-            std::string_view board_serial = {})
-            : librmcs::agent::CBoard(board_serial)
-            , imu_(1000, 0.2, 0.0)
-            , tf_(steering_infantry.tf_)
-            , dr16_(steering_infantry)
-            , gimbal_yaw_motor_(steering_infantry, steering_infantry_command, "/gimbal/yaw")
-            , gimbal_bullet_feeder_(
-                  steering_infantry, steering_infantry_command, "/gimbal/bullet_feeder")
-            , chassis_wheel_motors_(
-                  {steering_infantry, steering_infantry_command, "/chassis/left_front_wheel"},
-                  {steering_infantry, steering_infantry_command, "/chassis/left_back_wheel"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_back_wheel"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_front_wheel"})
-            , chassis_steer_motors_(
-                  {steering_infantry, steering_infantry_command, "/chassis/left_front_steering"},
-                  {steering_infantry, steering_infantry_command, "/chassis/left_back_steering"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_back_steering"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_front_steering"})
-            , supercap_(steering_infantry, steering_infantry_command) {
-
-            steering_infantry.register_output("/referee/serial", referee_serial_);
-
-            referee_serial_->read = [this](std::byte* buffer, size_t size) {
-                return referee_ring_buffer_receive_.pop_front_n(
-                    [&buffer](std::byte byte) noexcept { *buffer++ = byte; }, size);
-            };
-            referee_serial_->write = [this](const std::byte* buffer, size_t size) {
-                start_transmit().uart1_transmit(
-                    {.uart_data = std::span<const std::byte>{buffer, size}});
-                return size;
-            };
-            gimbal_yaw_motor_.configure(
-                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}.set_encoder_zero_point(
-                    static_cast<int>(
-                        steering_infantry.get_parameter("yaw_motor_zero_point").as_int())));
-
-            gimbal_bullet_feeder_.configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kM2006}
-                    .enable_multi_turn_angle()
-                    .set_reversed()
-                    .set_reduction_ratio(19 * 2));
-
-            for (auto& motor : chassis_wheel_motors_)
-                motor.configure(
-                    device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
-
-                        .set_reduction_ratio(11.)
-                        .enable_multi_turn_angle()
-                        .set_reversed());
-            chassis_steer_motors_[0].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("left_front_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            chassis_steer_motors_[1].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("left_back_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            chassis_steer_motors_[2].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("right_back_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            chassis_steer_motors_[3].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("right_front_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            steering_infantry.register_output(
-                "/chassis/yaw/velocity_imu", chassis_yaw_velocity_imu_, 0);
-        }
-
-        BottomBoard(const BottomBoard&) = delete;
-        BottomBoard& operator=(const BottomBoard&) = delete;
-        BottomBoard(BottomBoard&&) = delete;
-        BottomBoard& operator=(BottomBoard&&) = delete;
-
-        ~BottomBoard() override = default;
-
-        void update() {
-            imu_.update_status();
-            *chassis_yaw_velocity_imu_ = imu_.gy();
-            supercap_.update_status();
-
-            for (auto& motor : chassis_wheel_motors_)
-                motor.update_status();
-            for (auto& motor : chassis_steer_motors_)
-                motor.update_status();
-
-            dr16_.update_status();
-            gimbal_yaw_motor_.update_status();
-            tf_->set_state<rmcs_description::GimbalCenterLink, rmcs_description::YawLink>(
-                gimbal_yaw_motor_.angle());
-
-            gimbal_bullet_feeder_.update_status();
-        }
-
-        void command_update() {
-            if (can_transmission_mode_) {
-                auto builder = start_transmit();
-
-                builder.can1_transmit({
-                    .can_id = 0x200,
-                    .can_data =
-                        device::CanPacket8{
-                            chassis_wheel_motors_[0].generate_command(),
-                            chassis_wheel_motors_[1].generate_command(),
-                            chassis_wheel_motors_[2].generate_command(),
-                            chassis_wheel_motors_[3].generate_command(),
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can1_transmit({
-                    .can_id = 0x1FF,
-                    .can_data =
-                        device::CanPacket8{
-                            gimbal_bullet_feeder_.generate_command(),
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can1_transmit({
-                    .can_id = 0x1FE,
-                    .can_data =
-                        device::CanPacket8{
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            supercap_.generate_command(),
-                        }
-                            .as_bytes(),
-                });
-
-                auto steer_builder = start_transmit();
-                steer_builder.can2_transmit({
-                    .can_id = 0x1FE,
-                    .can_data =
-                        device::CanPacket8{
-                            chassis_steer_motors_[0].generate_command(),
-                            chassis_steer_motors_[1].generate_command(),
-                            chassis_steer_motors_[2].generate_command(),
-                            chassis_steer_motors_[3].generate_command(),
-                        }
-                            .as_bytes(),
-                });
-            } else {
-                auto builder = start_transmit();
-
-                builder.can1_transmit({
-                    .can_id = 0x200,
-                    .can_data =
-                        device::CanPacket8{
-                            chassis_wheel_motors_[0].generate_command(),
-                            chassis_wheel_motors_[1].generate_command(),
-                            chassis_wheel_motors_[2].generate_command(),
-                            chassis_wheel_motors_[3].generate_command(),
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can1_transmit({
-                    .can_id = 0x1FF,
-                    .can_data =
-                        device::CanPacket8{
-                            gimbal_bullet_feeder_.generate_command(),
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can2_transmit({
-                    .can_id = 0x142,
-                    .can_data = gimbal_yaw_motor_
-                                    .generate_velocity_command(
-                                        gimbal_yaw_motor_.control_velocity() - imu_.gy())
-                                    .as_bytes(),
-                });
             }
-            can_transmission_mode_ = !can_transmission_mode_;
-        }
-
-    private:
-        void dbus_receive_callback(const librmcs::data::UartDataView& data) override {
-            dr16_.store_status(data.uart_data.data(), data.uart_data.size());
-        }
-
-        void can1_receive_callback(const librmcs::data::CanDataView& data) override {
-            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
-                return;
-            auto can_id = data.can_id;
-            if (can_id == 0x201)
-                chassis_wheel_motors_[0].store_status(data.can_data);
-            else if (can_id == 0x202)
-                chassis_wheel_motors_[1].store_status(data.can_data);
-            else if (can_id == 0x203)
-                chassis_wheel_motors_[2].store_status(data.can_data);
-            else if (can_id == 0x204)
-                chassis_wheel_motors_[3].store_status(data.can_data);
-            else if (can_id == 0x205)
-                gimbal_bullet_feeder_.store_status(data.can_data);
-            else if (can_id == 0x300)
-                supercap_.store_status(data.can_data);
-        }
-
-        void can2_receive_callback(const librmcs::data::CanDataView& data) override {
-            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
-                return;
-            auto can_id = data.can_id;
-            if (can_id == 0x142)
-                gimbal_yaw_motor_.store_status(data.can_data);
-            else if (can_id == 0x205)
-                chassis_steer_motors_[0].store_status(data.can_data);
-            else if (can_id == 0x206)
-                chassis_steer_motors_[1].store_status(data.can_data);
-            else if (can_id == 0x207)
-                chassis_steer_motors_[2].store_status(data.can_data);
-            else if (can_id == 0x208)
-                chassis_steer_motors_[3].store_status(data.can_data);
-        }
-
-        void uart1_receive_callback(const librmcs::data::UartDataView& data) override {
-            const auto* uart_data = data.uart_data.data();
-            referee_ring_buffer_receive_.emplace_back_n(
-                [&uart_data](std::byte* storage) noexcept { *storage = *uart_data++; },
-                data.uart_data.size());
         }
 
         void accelerometer_receive_callback(
@@ -501,32 +226,311 @@ private:
             imu_.store_gyroscope_status(data.x, data.y, data.z);
         }
 
-        bool can_transmission_mode_ = true;
-        device::Bmi088 imu_;
         OutputInterface<rmcs_description::Tf>& tf_;
-        OutputInterface<bool> powermeter_control_enabled_;
-        OutputInterface<double> powermeter_charge_power_limit_;
 
+        device::Bmi088 imu_;
+
+        device::LkMotor gimbal_pitch_motor_;
+        device::DjiMotor gimbal_left_friction_;
+        device::DjiMotor gimbal_right_friction_;
+
+        OutputInterface<double> gimbal_yaw_velocity_imu_;
+        OutputInterface<double> gimbal_pitch_velocity_imu_;
+    };
+
+    class BottomBoard final : private librmcs::agent::RmcsBoardLite {
+    public:
+        friend class SteeringInfantry;
+        explicit BottomBoard(
+            SteeringInfantry& climbable_infantry,
+            SteeringInfantryCommand& climbable_infantry_command, std::string_view board_serial = {})
+            : librmcs::agent::RmcsBoardLite(board_serial)
+            , tf_(climbable_infantry.tf_)
+            , imu_(1000, 0.2, 0.0)
+            , dr16_(climbable_infantry)
+            , gimbal_yaw_motor_(climbable_infantry, climbable_infantry_command, "/gimbal/yaw")
+            , supercap_(climbable_infantry, climbable_infantry_command)
+            , gimbal_bullet_feeder_(
+                  climbable_infantry, climbable_infantry_command, "/gimbal/bullet_feeder")
+            , chassis_front_steering_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_front_steering"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_front_steering"})
+            , chassis_front_wheel_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_front_wheel"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_front_wheel"})
+            , chassis_back_steering_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_back_steering"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_back_steering"})
+            , chassis_back_wheel_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_back_wheel"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_back_wheel"}) {
+            gimbal_yaw_motor_.configure(
+                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}.set_encoder_zero_point(
+                    static_cast<int>(
+                        climbable_infantry.get_parameter("yaw_motor_zero_point").as_int())));
+            gimbal_bullet_feeder_.configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .enable_multi_turn_angle());
+
+            chassis_front_steering_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("left_front_zero_point").as_int()))
+                    .set_reversed());
+            chassis_front_steering_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("right_front_zero_point").as_int()))
+                    .set_reversed());
+            chassis_back_steering_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("left_back_zero_point").as_int()))
+                    .set_reversed());
+            chassis_back_steering_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("right_back_zero_point").as_int()))
+                    .set_reversed());
+
+            chassis_front_wheel_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+            chassis_front_wheel_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+            chassis_back_wheel_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+            chassis_back_wheel_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+
+            climbable_infantry.register_output("/referee/serial", referee_serial_);
+            referee_serial_->read = [this](std::byte* buffer, size_t size) {
+                return referee_ring_buffer_receive_.pop_front_n(
+                    [&buffer](std::byte byte) noexcept { *buffer++ = byte; }, size);
+            };
+            referee_serial_->write = [this](const std::byte* buffer, size_t size) {
+                start_transmit().uart0_transmit(
+                    {.uart_data = std::span<const std::byte>{buffer, size}});
+                return size;
+            };
+
+            climbable_infantry.register_output(
+                "/chassis/yaw/velocity_imu", chassis_yaw_velocity_imu_, 0);
+        }
+
+        BottomBoard(const BottomBoard&) = delete;
+        BottomBoard& operator=(const BottomBoard&) = delete;
+        BottomBoard(BottomBoard&&) = delete;
+        BottomBoard& operator=(BottomBoard&&) = delete;
+
+        ~BottomBoard() final = default;
+
+        void update() {
+            imu_.update_status();
+            dr16_.update_status();
+
+            *chassis_yaw_velocity_imu_ = imu_.gz();
+
+            gimbal_yaw_motor_.update_status();
+            supercap_.update_status();
+            gimbal_bullet_feeder_.update_status();
+
+            tf_->set_state<rmcs_description::GimbalCenterLink, rmcs_description::YawLink>(
+                gimbal_yaw_motor_.angle());
+
+            for (auto& motor : chassis_front_wheel_motors_)
+                motor.update_status();
+            for (auto& motor : chassis_front_steering_motors_)
+                motor.update_status();
+            for (auto& motor : chassis_back_wheel_motors_)
+                motor.update_status();
+            for (auto& motor : chassis_back_steering_motors_)
+                motor.update_status();
+        }
+
+        void command_update() {
+            auto builder = start_transmit();
+            builder.can0_transmit({
+                .can_id = 0x200,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_back_wheel_motors_[0].generate_command(),
+                        chassis_back_wheel_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can0_transmit({
+                .can_id = 0x1FE,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_back_steering_motors_[0].generate_command(),
+                        chassis_back_steering_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        supercap_.generate_command(),
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can1_transmit({
+                .can_id = 0x200,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_front_wheel_motors_[0].generate_command(),
+                        chassis_front_wheel_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can1_transmit({
+                .can_id = 0x1FE,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_front_steering_motors_[0].generate_command(),
+                        chassis_front_steering_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can2_transmit({
+                .can_id = 0x142,
+                .can_data = gimbal_yaw_motor_.generate_torque_command().as_bytes(),
+            });
+
+            builder.can3_transmit({
+                .can_id = 0x1FF,
+                .can_data =
+                    device::CanPacket8{
+                        gimbal_bullet_feeder_.generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                    }
+                        .as_bytes(),
+            });
+        }
+
+    private:
+        void can0_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+
+            if (can_id == 0x201) {
+                chassis_back_wheel_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x202) {
+                chassis_back_wheel_motors_[1].store_status(data.can_data);
+            } else if (can_id == 0x205) {
+                chassis_back_steering_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x206) {
+                chassis_back_steering_motors_[1].store_status(data.can_data);
+            } else if (can_id == 0x300) {
+                supercap_.store_status(data.can_data);
+            }
+        }
+
+        void can1_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+
+            if (can_id == 0x201) {
+                chassis_front_wheel_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x202) {
+                chassis_front_wheel_motors_[1].store_status(data.can_data);
+            } else if (can_id == 0x205) {
+                chassis_front_steering_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x206) {
+                chassis_front_steering_motors_[1].store_status(data.can_data);
+            }
+        }
+
+        void can2_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+            if (can_id == 0x142) {
+                gimbal_yaw_motor_.store_status(data.can_data);
+            }
+        }
+
+        void can3_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+
+            if (can_id == 0x205) {
+                gimbal_bullet_feeder_.store_status(data.can_data);
+            }
+        }
+
+        void uart0_receive_callback(const librmcs::data::UartDataView& data) override {
+            const auto* uart_data = data.uart_data.data();
+            referee_ring_buffer_receive_.emplace_back_n(
+                [&uart_data](std::byte* storage) noexcept { *storage = *uart_data++; },
+                data.uart_data.size());
+        }
+
+        void dbus_receive_callback(const librmcs::data::UartDataView& data) override {
+            dr16_.store_status(data.uart_data.data(), data.uart_data.size());
+        }
+
+        void accelerometer_receive_callback(
+            const librmcs::data::AccelerometerDataView& data) override {
+            imu_.store_accelerometer_status(data.x, data.y, data.z);
+        }
+
+        void gyroscope_receive_callback(const librmcs::data::GyroscopeDataView& data) override {
+            imu_.store_gyroscope_status(data.x, data.y, data.z);
+        }
+
+        OutputInterface<rmcs_description::Tf>& tf_;
+
+        device::Bmi088 imu_;
         device::Dr16 dr16_;
+
         device::LkMotor gimbal_yaw_motor_;
-        device::DjiMotor gimbal_bullet_feeder_;
-        device::DjiMotor chassis_wheel_motors_[4];
-        device::DjiMotor chassis_steer_motors_[4];
+
         device::Supercap supercap_;
+        device::DjiMotor gimbal_bullet_feeder_;
+
+        device::DjiMotor chassis_front_steering_motors_[2];
+        device::DjiMotor chassis_front_wheel_motors_[2];
+        device::DjiMotor chassis_back_steering_motors_[2];
+        device::DjiMotor chassis_back_wheel_motors_[2];
 
         rmcs_utility::RingBuffer<std::byte> referee_ring_buffer_receive_{256};
         OutputInterface<rmcs_msgs::SerialInterface> referee_serial_;
+
         OutputInterface<double> chassis_yaw_velocity_imu_;
     };
 
     OutputInterface<rmcs_description::Tf> tf_;
 
-    std::shared_ptr<SteeringInfantryCommand> command_component_;
-    std::shared_ptr<TopBoard> top_board_;
-    std::shared_ptr<BottomBoard> bottom_board_;
-
     rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr gimbal_calibrate_subscription_;
     rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr steers_calibrate_subscription_;
+
+    std::shared_ptr<TopBoard> top_board_;
+    std::shared_ptr<BottomBoard> bottom_board_;
 };
 
 } // namespace rmcs_core::hardware


### PR DESCRIPTION
Rebuild the maintained steering-infantry variant from the climbable-infantry branch while dropping the stair-climbing control chain, dedicated climber motors, and VT13-specific remote-control path. Keep climbable-infantry itself unchanged as an active vehicle; this merge only ports the maintained non-climbing subset back to steering-infantry, because the historical steering-infantry implementation is no longer maintained.

Update SteeringInfantry to the rmcs-board-lite split top/bottom board path and refresh its bringup config for the current maintained robot. Also restore the original /gimbal/calibrate and /steers/calibrate semantics, remove the temporary yaw watchdog path, make pitch control explicitly use LK velocity commands, and recover accidentally removed mainline content while keeping only the required steering-infantry merge delta.

Update librmcs from v3.2.0b0 to v3.2.0 for the required board-lite SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 概述

本PR将 climbable-infantry 分支中维护的非爬梯子集重新引入 steering-infantry 变体，因为历史上的 steering-infantry 实现已不再维护。此PR保持 climbable-infantry 本身不变，仅修改 steering-infantry 部分。主要变更包括：迁移至 rmcs-board-lite 分割式上下板路径、刷新维护机器人的启动配置、恢复原始的 /gimbal/calibrate 和 /steers/calibrate 语义、移除临时的偏航监视路径、显式使用LK速度命令进行俯仰控制、恢复意外删除的主线内容（仅保留必要的 steering-infantry 差异），以及将 librmcs 从 v3.2.0b0 更新到 v3.2.0 以支持 board-lite SDK。

## 变更详情

**steering-infantry.yaml** 
- 更新 `rmcs_executor.ros__parameters.components` 的组件映射键，使用新的简短命名（包括硬件、裁判状态与交互、UI、控制器及其PID变体等）
- 将 `steeringInfantry_hardware` 重命名为 `Infantry_hardware`，更新板卡序列号与各电机/轮零点参数
- 调整 `gimbal_controller` 的上下限参数
- 更新 `pitch_angle_pid_controller` 和 `yaw_angle_pid_controller` 的增益（kp/ki/kd）及其测量/控制话题路径
- 更新 `yaw_velocity_pid_controller` 的测量/设定/控制话题路径与PID参数
- 调整摩擦轮控制器的目标速度（从600.0改为590.0）及软启动/停止时长（从1.0改为0.3）
- 调整弹药供给和发射相关参数，包括 `bullet_feeder_velocity_pid_controller` 的增益和 `steering_wheel_controller` 的关键参数

**CMakeLists.txt**
- 更新 `librmcs` SDK版本：从v3.2.0-beta.0改为v3.2.0，同时更新对应的下载地址和SHA256校验值

**steering-infantry.cpp**
- 更新头文件依赖，引入 `std::atomic` 和 `librmcs/agent/rmcs_board_lite.hpp`
- 调整 `steers_calibrate_subscription_callback` 的日志和参数实现
- 重构 `TopBoard` 基类：从 `librmcs::agent::CBoard` 切换为 `librmcs::agent::RmcsBoardLite`
- 调整IMU处理路径（`bmi088_` 相关成员替换为 `imu_`）
- 更新 `TopBoard::command_update()` 的CAN发送数据组织，调整摩擦轮和俯仰电机的报文结构
- 重写 `TopBoard` 的CAN接收回调，更新CAN ID判定和状态映射关系
- 大幅重构 `BottomBoard` 实现：由 `CBoard` 改为 `RmcsBoardLite` 风格，扩展状态刷新逻辑，调整CAN发送策略为固定多通道报文发送，移除旧的 `can_transmission_mode_` 分支切换逻辑
- 调整 `BottomBoard` 的CAN/串口回调映射关系
- 简化 `SteeringInfantry` 外层结构：移除外层直接持有的CAN/IMU/舵轮电机成员，改为由 `TopBoard`/`BottomBoard` 内部持有，外层仅保留 `tf_`、标定订阅和双指针引用

<!-- end of auto-generated comment: release notes by coderabbit.ai -->