### PR TITLE
feat: Fold climbable-infantry into maintained steering-infantry

### DIFF
--- a/rmcs_ws/src/rmcs_bringup/config/steering-infantry.yaml
+++ b/rmcs_ws/src/rmcs_bringup/config/steering-infantry.yaml
@@ -2,18 +2,18 @@ rmcs_executor:
   ros__parameters:
     update_rate: 1000.0
     components:
-      - rmcs_core::hardware::SteeringInfantry -> steeringInfantry_hardware
+      - rmcs_core::hardware::SteeringInfantry -> Infantry_hardware
 
       - rmcs_core::referee::Status -> referee_status
-      - rmcs_core::referee::Command -> referee_command
-
       - rmcs_core::referee::command::Interaction -> referee_interaction
       - rmcs_core::referee::command::interaction::Ui -> referee_ui
-      # - rmcs_core::referee::app::ui::Infantry -> referee_ui_infantry
+      - rmcs_core::referee::app::ui::Infantry -> referee_ui_infantry
+      - rmcs_core::referee::Command -> referee_command
 
       - rmcs_core::controller::gimbal::SimpleGimbalController -> gimbal_controller
-      - rmcs_core::controller::pid::ErrorPidController -> yaw_angle_pid_controller
       - rmcs_core::controller::pid::ErrorPidController -> pitch_angle_pid_controller
+      - rmcs_core::controller::pid::ErrorPidController -> yaw_angle_pid_controller
+      - rmcs_core::controller::pid::PidController -> yaw_velocity_pid_controller
 
       - rmcs_core::controller::shooting::FrictionWheelController -> friction_wheel_controller
       - rmcs_core::controller::shooting::HeatController -> heat_controller
@@ -26,37 +26,47 @@ rmcs_executor:
       - rmcs_core::controller::chassis::ChassisPowerController -> chassis_power_controller
       - rmcs_core::controller::chassis::SteeringWheelController -> steering_wheel_controller
 
-steeringInfantry_hardware:
+Infantry_hardware:
   ros__parameters:
-    board_serial_top_board: "(TODO)"
-    board_serial_bottom_board: "(TODO)"
-    yaw_motor_zero_point: 32285
-    pitch_motor_zero_point: 6321
-    left_front_zero_point: 7848
-    left_back_zero_point: 5770
-    right_back_zero_point: 2380
-    right_front_zero_point: 1705
+    board_serial_top_board: "AF-B4E5-CE0E-4342-FF2C-F9E2-DE47-2D85-9B75"
+    board_serial_bottom_board: "AF-EEF5-24BA-6675-F1B1-C797-50AF-869C-870E"
+    yaw_motor_zero_point: 20993
+    pitch_motor_zero_point: 18874
+    left_front_zero_point: 1695
+    right_front_zero_point: 5068
+    left_back_zero_point: 7870
+    right_back_zero_point: 3141
+
 
 gimbal_controller:
   ros__parameters:
-    upper_limit: -0.39518
-    lower_limit: 0.36
-
-yaw_angle_pid_controller:
-  ros__parameters:
-    measurement: /gimbal/yaw/control_angle_error
-    control: /gimbal/yaw/control_velocity
-    kp: 16.0
-    ki: 0.0
-    kd: 0.0
+    upper_limit: -0.54
+    lower_limit: 0.274
 
 pitch_angle_pid_controller:
   ros__parameters:
     measurement: /gimbal/pitch/control_angle_error
     control: /gimbal/pitch/control_velocity
-    kp: 10.00
+    kp: 15.0
     ki: 0.0
-    kd: 0.0
+    kd: 1.5
+
+yaw_angle_pid_controller:
+  ros__parameters:
+    measurement: /gimbal/yaw/control_angle_error
+    control: /gimbal/yaw/control_velocity
+    kp: 20.0
+    ki: 0.0
+    kd: 0.9
+
+yaw_velocity_pid_controller:
+  ros__parameters:
+    measurement: /gimbal/yaw/velocity_imu
+    setpoint: /gimbal/yaw/control_velocity
+    control: /gimbal/yaw/control_torque
+    kp: 2.5
+    ki: 0.00
+    kd: 0.6
 
 friction_wheel_controller:
   ros__parameters:
@@ -64,9 +74,9 @@ friction_wheel_controller:
       - /gimbal/left_friction
       - /gimbal/right_friction
     friction_velocities:
-      - 600.0
-      - 600.0
-    friction_soft_start_stop_time: 1.0
+      - 590.0
+      - 590.0
+    friction_soft_start_stop_time: 0.3
 
 heat_controller:
   ros__parameters:
@@ -75,8 +85,8 @@ heat_controller:
 
 bullet_feeder_controller:
   ros__parameters:
-    bullets_per_feeder_turn: 10.0
-    shot_frequency: 24.0
+    bullets_per_feeder_turn: 9.0
+    shot_frequency: 27.0
     safe_shot_frequency: 10.0
     eject_frequency: 15.0
     eject_time: 0.15
@@ -86,8 +96,8 @@ bullet_feeder_controller:
 
 shooting_recorder:
   ros__parameters:
-    friction_wheel_count: 4
-    log_mode: 2 # 1: trigger, 2: timing
+    friction_wheel_count: 2
+    log_mode: 1
 
 left_friction_velocity_pid_controller:
   ros__parameters:
@@ -112,15 +122,15 @@ bullet_feeder_velocity_pid_controller:
     measurement: /gimbal/bullet_feeder/velocity
     setpoint: /gimbal/bullet_feeder/control_velocity
     control: /gimbal/bullet_feeder/control_torque
-    kp: 0.283
+    kp: 0.7
     ki: 0.0
     kd: 0.0
 
 steering_wheel_controller:
   ros__parameters:
-    mess: 19.0
-    moment_of_inertia: 1.0
-    vehicle_radius: 0.24678
+    mess: 22.0
+    moment_of_inertia: 1.08
+    vehicle_radius: 0.28284271247462
     wheel_radius: 0.055
     friction_coefficient: 0.6
     k1: 2.958580e+00

--- a/rmcs_ws/src/rmcs_bringup/config/steering-infantry.yaml
+++ b/rmcs_ws/src/rmcs_bringup/config/steering-infantry.yaml
@@ -2,7 +2,7 @@ rmcs_executor:
   ros__parameters:
     update_rate: 1000.0
     components:
-      - rmcs_core::hardware::SteeringInfantry -> Infantry_hardware
+      - rmcs_core::hardware::SteeringInfantry -> infantry_hardware
 
       - rmcs_core::referee::Status -> referee_status
       - rmcs_core::referee::command::Interaction -> referee_interaction
@@ -26,7 +26,7 @@ rmcs_executor:
       - rmcs_core::controller::chassis::ChassisPowerController -> chassis_power_controller
       - rmcs_core::controller::chassis::SteeringWheelController -> steering_wheel_controller
 
-Infantry_hardware:
+infantry_hardware:
   ros__parameters:
     board_serial_top_board: "AF-B4E5-CE0E-4342-FF2C-F9E2-DE47-2D85-9B75"
     board_serial_bottom_board: "AF-EEF5-24BA-6675-F1B1-C797-50AF-869C-870E"

--- a/rmcs_ws/src/rmcs_core/CMakeLists.txt
+++ b/rmcs_ws/src/rmcs_core/CMakeLists.txt
@@ -17,8 +17,8 @@ include(FetchContent)
 set(BUILD_STATIC_LIBRMCS ON CACHE BOOL "Build static librmcs SDK" FORCE)
 FetchContent_Declare(
   librmcs
-  URL https://github.com/Alliance-Algorithm/librmcs/releases/download/v3.2.0b0/librmcs-sdk-src-3.2.0-beta.0.zip
-  URL_HASH SHA256=391b642a31473fdb639573912e0fc6266c3819d787b91440310cd1025af1dc3c
+  URL https://github.com/Alliance-Algorithm/librmcs/releases/download/v3.2.0/librmcs-sdk-src-3.2.0.zip
+  URL_HASH SHA256=f81c3af7fbcf35727a8a7586200db8e9bf668ee0f448529de4bfd3eb7c36ed6f
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(librmcs)

--- a/rmcs_ws/src/rmcs_core/src/hardware/steering-infantry.cpp
+++ b/rmcs_ws/src/rmcs_core/src/hardware/steering-infantry.cpp
@@ -1,13 +1,15 @@
+#include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <span>
 #include <string_view>
 #include <tuple>
-#include <utility>
 
 #include <eigen3/Eigen/Dense>
 #include <librmcs/agent/c_board.hpp>
+#include <librmcs/agent/rmcs_board_lite.hpp>
 #include <librmcs/data/datas.hpp>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
@@ -42,7 +44,6 @@ public:
               create_partner_component<SteeringInfantryCommand>(
                   get_component_name() + "_command", *this)) {
         register_output("/tf", tf_);
-
         gimbal_calibrate_subscription_ = create_subscription<std_msgs::msg::Int32>(
             "/gimbal/calibrate", rclcpp::QoS{0}, [this](std_msgs::msg::Int32::UniquePtr&& msg) {
                 gimbal_calibrate_subscription_callback(std::move(msg));
@@ -54,7 +55,6 @@ public:
 
         top_board_ = std::make_unique<TopBoard>(
             *this, *command_component_, get_parameter("board_serial_top_board").as_string());
-
         bottom_board_ = std::make_unique<BottomBoard>(
             *this, *command_component_, get_parameter("board_serial_bottom_board").as_string());
 
@@ -75,7 +75,6 @@ public:
     }
 
     void command_update() {
-
         top_board_->command_update();
         bottom_board_->command_update();
     }
@@ -93,70 +92,62 @@ private:
     void steers_calibrate_subscription_callback(std_msgs::msg::Int32::UniquePtr) {
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New left front offset: %d",
-            bottom_board_->chassis_steer_motors_[0].calibrate_zero_point());
+            bottom_board_->chassis_front_steering_motors_[0].calibrate_zero_point());
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New left back offset: %d",
-            bottom_board_->chassis_steer_motors_[1].calibrate_zero_point());
+            bottom_board_->chassis_back_steering_motors_[0].calibrate_zero_point());
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New right back offset: %d",
-            bottom_board_->chassis_steer_motors_[2].calibrate_zero_point());
+            bottom_board_->chassis_back_steering_motors_[1].calibrate_zero_point());
         RCLCPP_INFO(
             get_logger(), "[steer calibration] New right front offset: %d",
-            bottom_board_->chassis_steer_motors_[3].calibrate_zero_point());
+            bottom_board_->chassis_front_steering_motors_[1].calibrate_zero_point());
     }
+
     class SteeringInfantryCommand : public rmcs_executor::Component {
     public:
-        explicit SteeringInfantryCommand(SteeringInfantry& steering_infantry)
-            : steering_infantry(steering_infantry) {}
+        explicit SteeringInfantryCommand(SteeringInfantry& infantry_)
+            : infantry_(infantry_) {}
 
-        void update() override { steering_infantry.command_update(); }
+        void update() override { infantry_.command_update(); }
 
-        SteeringInfantry& steering_infantry;
+        SteeringInfantry& infantry_;
     };
+    std::shared_ptr<SteeringInfantryCommand> command_component_;
 
-    class TopBoard final : private librmcs::agent::CBoard {
+    class TopBoard final : private librmcs::agent::RmcsBoardLite {
     public:
         friend class SteeringInfantry;
         explicit TopBoard(
-            SteeringInfantry& steering_infantry, SteeringInfantryCommand& steering_infantry_command,
-            std::string_view board_serial = {})
-            : librmcs::agent::CBoard(board_serial)
-            , tf_(steering_infantry.tf_)
-            , bmi088_(1000, 0.2, 0.0)
-            , gimbal_pitch_motor_(steering_infantry, steering_infantry_command, "/gimbal/pitch")
+            SteeringInfantry& climbable_infantry,
+            SteeringInfantryCommand& climbable_infantry_command, std::string_view board_serial = {})
+            : librmcs::agent::RmcsBoardLite(board_serial, {true})
+            , tf_(climbable_infantry.tf_)
+            , imu_(1000, 0.2, 0.0)
+            , gimbal_pitch_motor_(climbable_infantry, climbable_infantry_command, "/gimbal/pitch")
             , gimbal_left_friction_(
-                  steering_infantry, steering_infantry_command, "/gimbal/left_friction")
+                  climbable_infantry, climbable_infantry_command, "/gimbal/left_friction")
             , gimbal_right_friction_(
-                  steering_infantry, steering_infantry_command, "/gimbal/right_friction") {
-            gimbal_pitch_motor_.configure(
-                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}.set_encoder_zero_point(
-                    static_cast<int>(
-                        steering_infantry.get_parameter("pitch_motor_zero_point").as_int())));
+                  climbable_infantry, climbable_infantry_command, "/gimbal/right_friction") {
 
+            gimbal_pitch_motor_.configure(
+                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("pitch_motor_zero_point").as_int()))
+                    .enable_multi_turn_angle());
             gimbal_left_friction_.configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kM3508}.set_reduction_ratio(1.));
             gimbal_right_friction_.configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
                     .set_reduction_ratio(1.)
                     .set_reversed());
-
-            steering_infantry.register_output(
-                "/gimbal/yaw/velocity_imu", gimbal_yaw_velocity_bmi088_);
-            steering_infantry.register_output(
-                "/gimbal/pitch/velocity_imu", gimbal_pitch_velocity_bmi088_);
-
-            bmi088_.set_coordinate_mapping([](double x, double y, double z) {
-                // Get the mapping with the following code.
-                // The rotation angle must be an exact multiple of 90 degrees, otherwise
-                // use a matrix.
-
-                // Eigen::AngleAxisd pitch_link_to_bmi088_link{
-                //     std::numbers::pi / 2, Eigen::Vector3d::UnitZ()};
-                // Eigen::Vector3d mapping = pitch_link_to_bmi088_link * Eigen::Vector3d{1, 2, 3};
-                // std::cout << mapping << std::endl;
-
-                return std::make_tuple(x, y, z);
-            });
+            climbable_infantry.register_output(
+                "/gimbal/yaw/velocity_imu", gimbal_yaw_velocity_imu_);
+            climbable_infantry.register_output(
+                "/gimbal/pitch/velocity_imu", gimbal_pitch_velocity_imu_);
+            imu_.set_coordinate_mapping(
+                [](double x, double y, double z) { return std::make_tuple(x, y, z); });
         }
 
         TopBoard(const TopBoard&) = delete;
@@ -164,18 +155,17 @@ private:
         TopBoard(TopBoard&&) = delete;
         TopBoard& operator=(TopBoard&&) = delete;
 
-        ~TopBoard() override = default;
+        ~TopBoard() final = default;
 
         void update() {
-            bmi088_.update_status();
-            const Eigen::Quaterniond gimbal_bmi088_pose{
-                bmi088_.q0(), bmi088_.q1(), bmi088_.q2(), bmi088_.q3()};
+            imu_.update_status();
+            const Eigen::Quaterniond gimbal_imu_pose{imu_.q0(), imu_.q1(), imu_.q2(), imu_.q3()};
 
             tf_->set_transform<rmcs_description::PitchLink, rmcs_description::OdomImu>(
-                gimbal_bmi088_pose.conjugate());
+                gimbal_imu_pose.conjugate());
 
-            *gimbal_yaw_velocity_bmi088_ = bmi088_.gz();
-            *gimbal_pitch_velocity_bmi088_ = bmi088_.gy();
+            *gimbal_yaw_velocity_imu_ = imu_.gz();
+            *gimbal_pitch_velocity_imu_ = imu_.gy();
 
             gimbal_pitch_motor_.update_status();
             gimbal_left_friction_.update_status();
@@ -192,19 +182,17 @@ private:
                 .can_id = 0x200,
                 .can_data =
                     device::CanPacket8{
-                        device::CanPacket8::PaddingQuarter{},
-                        device::CanPacket8::PaddingQuarter{},
-                        gimbal_left_friction_.generate_command(),
                         gimbal_right_friction_.generate_command(),
+                        gimbal_left_friction_.generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
                     }
                         .as_bytes(),
             });
 
             builder.can2_transmit({
-                .can_id = 0x142,
-                .can_data = gimbal_pitch_motor_
-                                .generate_velocity_command(gimbal_pitch_motor_.control_velocity())
-                                .as_bytes(),
+                .can_id = 0x143,
+                .can_data = gimbal_pitch_motor_.generate_velocity_command().as_bytes(),
             });
         }
 
@@ -213,283 +201,20 @@ private:
             if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
                 return;
             auto can_id = data.can_id;
-            if (can_id == 0x203) {
-                gimbal_left_friction_.store_status(data.can_data);
-            } else if (can_id == 0x204) {
+            if (can_id == 0x201) {
                 gimbal_right_friction_.store_status(data.can_data);
+            } else if (can_id == 0x202) {
+                gimbal_left_friction_.store_status(data.can_data);
             }
         }
+
         void can2_receive_callback(const librmcs::data::CanDataView& data) override {
             if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
                 return;
             auto can_id = data.can_id;
-            if (can_id == 0x142)
+            if (can_id == 0x143) {
                 gimbal_pitch_motor_.store_status(data.can_data);
-        }
-        void accelerometer_receive_callback(
-            const librmcs::data::AccelerometerDataView& data) override {
-            bmi088_.store_accelerometer_status(data.x, data.y, data.z);
-        }
-        void gyroscope_receive_callback(const librmcs::data::GyroscopeDataView& data) override {
-            bmi088_.store_gyroscope_status(data.x, data.y, data.z);
-        }
-        OutputInterface<rmcs_description::Tf>& tf_;
-
-        OutputInterface<double> gimbal_yaw_velocity_bmi088_;
-        OutputInterface<double> gimbal_pitch_velocity_bmi088_;
-
-        device::Bmi088 bmi088_;
-        device::LkMotor gimbal_pitch_motor_;
-        device::DjiMotor gimbal_left_friction_;
-        device::DjiMotor gimbal_right_friction_;
-    };
-
-    class BottomBoard final : private librmcs::agent::CBoard {
-    public:
-        friend class SteeringInfantry;
-
-        explicit BottomBoard(
-            SteeringInfantry& steering_infantry, SteeringInfantryCommand& steering_infantry_command,
-            std::string_view board_serial = {})
-            : librmcs::agent::CBoard(board_serial)
-            , imu_(1000, 0.2, 0.0)
-            , tf_(steering_infantry.tf_)
-            , dr16_(steering_infantry)
-            , gimbal_yaw_motor_(steering_infantry, steering_infantry_command, "/gimbal/yaw")
-            , gimbal_bullet_feeder_(
-                  steering_infantry, steering_infantry_command, "/gimbal/bullet_feeder")
-            , chassis_wheel_motors_(
-                  {steering_infantry, steering_infantry_command, "/chassis/left_front_wheel"},
-                  {steering_infantry, steering_infantry_command, "/chassis/left_back_wheel"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_back_wheel"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_front_wheel"})
-            , chassis_steer_motors_(
-                  {steering_infantry, steering_infantry_command, "/chassis/left_front_steering"},
-                  {steering_infantry, steering_infantry_command, "/chassis/left_back_steering"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_back_steering"},
-                  {steering_infantry, steering_infantry_command, "/chassis/right_front_steering"})
-            , supercap_(steering_infantry, steering_infantry_command) {
-
-            steering_infantry.register_output("/referee/serial", referee_serial_);
-
-            referee_serial_->read = [this](std::byte* buffer, size_t size) {
-                return referee_ring_buffer_receive_.pop_front_n(
-                    [&buffer](std::byte byte) noexcept { *buffer++ = byte; }, size);
-            };
-            referee_serial_->write = [this](const std::byte* buffer, size_t size) {
-                start_transmit().uart1_transmit(
-                    {.uart_data = std::span<const std::byte>{buffer, size}});
-                return size;
-            };
-            gimbal_yaw_motor_.configure(
-                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}.set_encoder_zero_point(
-                    static_cast<int>(
-                        steering_infantry.get_parameter("yaw_motor_zero_point").as_int())));
-
-            gimbal_bullet_feeder_.configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kM2006}
-                    .enable_multi_turn_angle()
-                    .set_reversed()
-                    .set_reduction_ratio(19 * 2));
-
-            for (auto& motor : chassis_wheel_motors_)
-                motor.configure(
-                    device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
-
-                        .set_reduction_ratio(11.)
-                        .enable_multi_turn_angle()
-                        .set_reversed());
-            chassis_steer_motors_[0].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("left_front_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            chassis_steer_motors_[1].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("left_back_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            chassis_steer_motors_[2].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("right_back_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            chassis_steer_motors_[3].configure(
-                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
-                    .set_reversed()
-                    .set_encoder_zero_point(
-                        static_cast<int>(
-                            steering_infantry.get_parameter("right_front_zero_point").as_int()))
-                    .enable_multi_turn_angle());
-            steering_infantry.register_output(
-                "/chassis/yaw/velocity_imu", chassis_yaw_velocity_imu_, 0);
-        }
-
-        BottomBoard(const BottomBoard&) = delete;
-        BottomBoard& operator=(const BottomBoard&) = delete;
-        BottomBoard(BottomBoard&&) = delete;
-        BottomBoard& operator=(BottomBoard&&) = delete;
-
-        ~BottomBoard() override = default;
-
-        void update() {
-            imu_.update_status();
-            *chassis_yaw_velocity_imu_ = imu_.gy();
-            supercap_.update_status();
-
-            for (auto& motor : chassis_wheel_motors_)
-                motor.update_status();
-            for (auto& motor : chassis_steer_motors_)
-                motor.update_status();
-
-            dr16_.update_status();
-            gimbal_yaw_motor_.update_status();
-            tf_->set_state<rmcs_description::GimbalCenterLink, rmcs_description::YawLink>(
-                gimbal_yaw_motor_.angle());
-
-            gimbal_bullet_feeder_.update_status();
-        }
-
-        void command_update() {
-            if (can_transmission_mode_) {
-                auto builder = start_transmit();
-
-                builder.can1_transmit({
-                    .can_id = 0x200,
-                    .can_data =
-                        device::CanPacket8{
-                            chassis_wheel_motors_[0].generate_command(),
-                            chassis_wheel_motors_[1].generate_command(),
-                            chassis_wheel_motors_[2].generate_command(),
-                            chassis_wheel_motors_[3].generate_command(),
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can1_transmit({
-                    .can_id = 0x1FF,
-                    .can_data =
-                        device::CanPacket8{
-                            gimbal_bullet_feeder_.generate_command(),
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can1_transmit({
-                    .can_id = 0x1FE,
-                    .can_data =
-                        device::CanPacket8{
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            supercap_.generate_command(),
-                        }
-                            .as_bytes(),
-                });
-
-                auto steer_builder = start_transmit();
-                steer_builder.can2_transmit({
-                    .can_id = 0x1FE,
-                    .can_data =
-                        device::CanPacket8{
-                            chassis_steer_motors_[0].generate_command(),
-                            chassis_steer_motors_[1].generate_command(),
-                            chassis_steer_motors_[2].generate_command(),
-                            chassis_steer_motors_[3].generate_command(),
-                        }
-                            .as_bytes(),
-                });
-            } else {
-                auto builder = start_transmit();
-
-                builder.can1_transmit({
-                    .can_id = 0x200,
-                    .can_data =
-                        device::CanPacket8{
-                            chassis_wheel_motors_[0].generate_command(),
-                            chassis_wheel_motors_[1].generate_command(),
-                            chassis_wheel_motors_[2].generate_command(),
-                            chassis_wheel_motors_[3].generate_command(),
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can1_transmit({
-                    .can_id = 0x1FF,
-                    .can_data =
-                        device::CanPacket8{
-                            gimbal_bullet_feeder_.generate_command(),
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                            device::CanPacket8::PaddingQuarter{},
-                        }
-                            .as_bytes(),
-                });
-
-                builder.can2_transmit({
-                    .can_id = 0x142,
-                    .can_data = gimbal_yaw_motor_
-                                    .generate_velocity_command(
-                                        gimbal_yaw_motor_.control_velocity() - imu_.gy())
-                                    .as_bytes(),
-                });
             }
-            can_transmission_mode_ = !can_transmission_mode_;
-        }
-
-    private:
-        void dbus_receive_callback(const librmcs::data::UartDataView& data) override {
-            dr16_.store_status(data.uart_data.data(), data.uart_data.size());
-        }
-
-        void can1_receive_callback(const librmcs::data::CanDataView& data) override {
-            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
-                return;
-            auto can_id = data.can_id;
-            if (can_id == 0x201)
-                chassis_wheel_motors_[0].store_status(data.can_data);
-            else if (can_id == 0x202)
-                chassis_wheel_motors_[1].store_status(data.can_data);
-            else if (can_id == 0x203)
-                chassis_wheel_motors_[2].store_status(data.can_data);
-            else if (can_id == 0x204)
-                chassis_wheel_motors_[3].store_status(data.can_data);
-            else if (can_id == 0x205)
-                gimbal_bullet_feeder_.store_status(data.can_data);
-            else if (can_id == 0x300)
-                supercap_.store_status(data.can_data);
-        }
-
-        void can2_receive_callback(const librmcs::data::CanDataView& data) override {
-            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
-                return;
-            auto can_id = data.can_id;
-            if (can_id == 0x142)
-                gimbal_yaw_motor_.store_status(data.can_data);
-            else if (can_id == 0x205)
-                chassis_steer_motors_[0].store_status(data.can_data);
-            else if (can_id == 0x206)
-                chassis_steer_motors_[1].store_status(data.can_data);
-            else if (can_id == 0x207)
-                chassis_steer_motors_[2].store_status(data.can_data);
-            else if (can_id == 0x208)
-                chassis_steer_motors_[3].store_status(data.can_data);
-        }
-
-        void uart1_receive_callback(const librmcs::data::UartDataView& data) override {
-            const auto* uart_data = data.uart_data.data();
-            referee_ring_buffer_receive_.emplace_back_n(
-                [&uart_data](std::byte* storage) noexcept { *storage = *uart_data++; },
-                data.uart_data.size());
         }
 
         void accelerometer_receive_callback(
@@ -501,32 +226,311 @@ private:
             imu_.store_gyroscope_status(data.x, data.y, data.z);
         }
 
-        bool can_transmission_mode_ = true;
-        device::Bmi088 imu_;
         OutputInterface<rmcs_description::Tf>& tf_;
-        OutputInterface<bool> powermeter_control_enabled_;
-        OutputInterface<double> powermeter_charge_power_limit_;
 
+        device::Bmi088 imu_;
+
+        device::LkMotor gimbal_pitch_motor_;
+        device::DjiMotor gimbal_left_friction_;
+        device::DjiMotor gimbal_right_friction_;
+
+        OutputInterface<double> gimbal_yaw_velocity_imu_;
+        OutputInterface<double> gimbal_pitch_velocity_imu_;
+    };
+
+    class BottomBoard final : private librmcs::agent::RmcsBoardLite {
+    public:
+        friend class SteeringInfantry;
+        explicit BottomBoard(
+            SteeringInfantry& climbable_infantry,
+            SteeringInfantryCommand& climbable_infantry_command, std::string_view board_serial = {})
+            : librmcs::agent::RmcsBoardLite(board_serial)
+            , tf_(climbable_infantry.tf_)
+            , imu_(1000, 0.2, 0.0)
+            , dr16_(climbable_infantry)
+            , gimbal_yaw_motor_(climbable_infantry, climbable_infantry_command, "/gimbal/yaw")
+            , supercap_(climbable_infantry, climbable_infantry_command)
+            , gimbal_bullet_feeder_(
+                  climbable_infantry, climbable_infantry_command, "/gimbal/bullet_feeder")
+            , chassis_front_steering_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_front_steering"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_front_steering"})
+            , chassis_front_wheel_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_front_wheel"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_front_wheel"})
+            , chassis_back_steering_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_back_steering"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_back_steering"})
+            , chassis_back_wheel_motors_(
+                  {climbable_infantry, climbable_infantry_command, "/chassis/left_back_wheel"},
+                  {climbable_infantry, climbable_infantry_command, "/chassis/right_back_wheel"}) {
+            gimbal_yaw_motor_.configure(
+                device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}.set_encoder_zero_point(
+                    static_cast<int>(
+                        climbable_infantry.get_parameter("yaw_motor_zero_point").as_int())));
+            gimbal_bullet_feeder_.configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .enable_multi_turn_angle());
+
+            chassis_front_steering_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("left_front_zero_point").as_int()))
+                    .set_reversed());
+            chassis_front_steering_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("right_front_zero_point").as_int()))
+                    .set_reversed());
+            chassis_back_steering_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("left_back_zero_point").as_int()))
+                    .set_reversed());
+            chassis_back_steering_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
+                    .set_encoder_zero_point(
+                        static_cast<int>(
+                            climbable_infantry.get_parameter("right_back_zero_point").as_int()))
+                    .set_reversed());
+
+            chassis_front_wheel_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+            chassis_front_wheel_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+            chassis_back_wheel_motors_[0].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+            chassis_back_wheel_motors_[1].configure(
+                device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
+                    .set_reversed()
+                    .set_reduction_ratio(2232. / 169.));
+
+            climbable_infantry.register_output("/referee/serial", referee_serial_);
+            referee_serial_->read = [this](std::byte* buffer, size_t size) {
+                return referee_ring_buffer_receive_.pop_front_n(
+                    [&buffer](std::byte byte) noexcept { *buffer++ = byte; }, size);
+            };
+            referee_serial_->write = [this](const std::byte* buffer, size_t size) {
+                start_transmit().uart0_transmit(
+                    {.uart_data = std::span<const std::byte>{buffer, size}});
+                return size;
+            };
+
+            climbable_infantry.register_output(
+                "/chassis/yaw/velocity_imu", chassis_yaw_velocity_imu_, 0);
+        }
+
+        BottomBoard(const BottomBoard&) = delete;
+        BottomBoard& operator=(const BottomBoard&) = delete;
+        BottomBoard(BottomBoard&&) = delete;
+        BottomBoard& operator=(BottomBoard&&) = delete;
+
+        ~BottomBoard() final = default;
+
+        void update() {
+            imu_.update_status();
+            dr16_.update_status();
+
+            *chassis_yaw_velocity_imu_ = imu_.gz();
+
+            gimbal_yaw_motor_.update_status();
+            supercap_.update_status();
+            gimbal_bullet_feeder_.update_status();
+
+            tf_->set_state<rmcs_description::GimbalCenterLink, rmcs_description::YawLink>(
+                gimbal_yaw_motor_.angle());
+
+            for (auto& motor : chassis_front_wheel_motors_)
+                motor.update_status();
+            for (auto& motor : chassis_front_steering_motors_)
+                motor.update_status();
+            for (auto& motor : chassis_back_wheel_motors_)
+                motor.update_status();
+            for (auto& motor : chassis_back_steering_motors_)
+                motor.update_status();
+        }
+
+        void command_update() {
+            auto builder = start_transmit();
+            builder.can0_transmit({
+                .can_id = 0x200,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_back_wheel_motors_[0].generate_command(),
+                        chassis_back_wheel_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can0_transmit({
+                .can_id = 0x1FE,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_back_steering_motors_[0].generate_command(),
+                        chassis_back_steering_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        supercap_.generate_command(),
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can1_transmit({
+                .can_id = 0x200,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_front_wheel_motors_[0].generate_command(),
+                        chassis_front_wheel_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can1_transmit({
+                .can_id = 0x1FE,
+                .can_data =
+                    device::CanPacket8{
+                        chassis_front_steering_motors_[0].generate_command(),
+                        chassis_front_steering_motors_[1].generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+
+                    }
+                        .as_bytes(),
+            });
+
+            builder.can2_transmit({
+                .can_id = 0x142,
+                .can_data = gimbal_yaw_motor_.generate_torque_command().as_bytes(),
+            });
+
+            builder.can3_transmit({
+                .can_id = 0x1FF,
+                .can_data =
+                    device::CanPacket8{
+                        gimbal_bullet_feeder_.generate_command(),
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                        device::CanPacket8::PaddingQuarter{},
+                    }
+                        .as_bytes(),
+            });
+        }
+
+    private:
+        void can0_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+
+            if (can_id == 0x201) {
+                chassis_back_wheel_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x202) {
+                chassis_back_wheel_motors_[1].store_status(data.can_data);
+            } else if (can_id == 0x205) {
+                chassis_back_steering_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x206) {
+                chassis_back_steering_motors_[1].store_status(data.can_data);
+            } else if (can_id == 0x300) {
+                supercap_.store_status(data.can_data);
+            }
+        }
+
+        void can1_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+
+            if (can_id == 0x201) {
+                chassis_front_wheel_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x202) {
+                chassis_front_wheel_motors_[1].store_status(data.can_data);
+            } else if (can_id == 0x205) {
+                chassis_front_steering_motors_[0].store_status(data.can_data);
+            } else if (can_id == 0x206) {
+                chassis_front_steering_motors_[1].store_status(data.can_data);
+            }
+        }
+
+        void can2_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+            if (can_id == 0x142) {
+                gimbal_yaw_motor_.store_status(data.can_data);
+            }
+        }
+
+        void can3_receive_callback(const librmcs::data::CanDataView& data) override {
+            if (data.is_extended_can_id || data.is_remote_transmission) [[unlikely]]
+                return;
+            auto can_id = data.can_id;
+
+            if (can_id == 0x205) {
+                gimbal_bullet_feeder_.store_status(data.can_data);
+            }
+        }
+
+        void uart0_receive_callback(const librmcs::data::UartDataView& data) override {
+            const auto* uart_data = data.uart_data.data();
+            referee_ring_buffer_receive_.emplace_back_n(
+                [&uart_data](std::byte* storage) noexcept { *storage = *uart_data++; },
+                data.uart_data.size());
+        }
+
+        void dbus_receive_callback(const librmcs::data::UartDataView& data) override {
+            dr16_.store_status(data.uart_data.data(), data.uart_data.size());
+        }
+
+        void accelerometer_receive_callback(
+            const librmcs::data::AccelerometerDataView& data) override {
+            imu_.store_accelerometer_status(data.x, data.y, data.z);
+        }
+
+        void gyroscope_receive_callback(const librmcs::data::GyroscopeDataView& data) override {
+            imu_.store_gyroscope_status(data.x, data.y, data.z);
+        }
+
+        OutputInterface<rmcs_description::Tf>& tf_;
+
+        device::Bmi088 imu_;
         device::Dr16 dr16_;
+
         device::LkMotor gimbal_yaw_motor_;
-        device::DjiMotor gimbal_bullet_feeder_;
-        device::DjiMotor chassis_wheel_motors_[4];
-        device::DjiMotor chassis_steer_motors_[4];
+
         device::Supercap supercap_;
+        device::DjiMotor gimbal_bullet_feeder_;
+
+        device::DjiMotor chassis_front_steering_motors_[2];
+        device::DjiMotor chassis_front_wheel_motors_[2];
+        device::DjiMotor chassis_back_steering_motors_[2];
+        device::DjiMotor chassis_back_wheel_motors_[2];
 
         rmcs_utility::RingBuffer<std::byte> referee_ring_buffer_receive_{256};
         OutputInterface<rmcs_msgs::SerialInterface> referee_serial_;
+
         OutputInterface<double> chassis_yaw_velocity_imu_;
     };
 
     OutputInterface<rmcs_description::Tf> tf_;
 
-    std::shared_ptr<SteeringInfantryCommand> command_component_;
-    std::shared_ptr<TopBoard> top_board_;
-    std::shared_ptr<BottomBoard> bottom_board_;
-
     rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr gimbal_calibrate_subscription_;
     rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr steers_calibrate_subscription_;
+
+    std::shared_ptr<TopBoard> top_board_;
+    std::shared_ptr<BottomBoard> bottom_board_;
 };
 
 } // namespace rmcs_core::hardware

--- a/rmcs_ws/src/rmcs_core/src/hardware/steering-infantry.cpp
+++ b/rmcs_ws/src/rmcs_core/src/hardware/steering-infantry.cpp
@@ -119,22 +119,22 @@ private:
     public:
         friend class SteeringInfantry;
         explicit TopBoard(
-            SteeringInfantry& climbable_infantry,
-            SteeringInfantryCommand& climbable_infantry_command, std::string_view board_serial = {})
+            SteeringInfantry& steering_infantry, SteeringInfantryCommand& steering_infantry_command,
+            std::string_view board_serial = {})
             : librmcs::agent::RmcsBoardLite(board_serial, {true})
-            , tf_(climbable_infantry.tf_)
+            , tf_(steering_infantry.tf_)
             , imu_(1000, 0.2, 0.0)
-            , gimbal_pitch_motor_(climbable_infantry, climbable_infantry_command, "/gimbal/pitch")
+            , gimbal_pitch_motor_(steering_infantry, steering_infantry_command, "/gimbal/pitch")
             , gimbal_left_friction_(
-                  climbable_infantry, climbable_infantry_command, "/gimbal/left_friction")
+                  steering_infantry, steering_infantry_command, "/gimbal/left_friction")
             , gimbal_right_friction_(
-                  climbable_infantry, climbable_infantry_command, "/gimbal/right_friction") {
+                  steering_infantry, steering_infantry_command, "/gimbal/right_friction") {
 
             gimbal_pitch_motor_.configure(
                 device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}
                     .set_encoder_zero_point(
                         static_cast<int>(
-                            climbable_infantry.get_parameter("pitch_motor_zero_point").as_int()))
+                            steering_infantry.get_parameter("pitch_motor_zero_point").as_int()))
                     .enable_multi_turn_angle());
             gimbal_left_friction_.configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kM3508}.set_reduction_ratio(1.));
@@ -142,9 +142,8 @@ private:
                 device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
                     .set_reduction_ratio(1.)
                     .set_reversed());
-            climbable_infantry.register_output(
-                "/gimbal/yaw/velocity_imu", gimbal_yaw_velocity_imu_);
-            climbable_infantry.register_output(
+            steering_infantry.register_output("/gimbal/yaw/velocity_imu", gimbal_yaw_velocity_imu_);
+            steering_infantry.register_output(
                 "/gimbal/pitch/velocity_imu", gimbal_pitch_velocity_imu_);
             imu_.set_coordinate_mapping(
                 [](double x, double y, double z) { return std::make_tuple(x, y, z); });
@@ -242,32 +241,32 @@ private:
     public:
         friend class SteeringInfantry;
         explicit BottomBoard(
-            SteeringInfantry& climbable_infantry,
-            SteeringInfantryCommand& climbable_infantry_command, std::string_view board_serial = {})
+            SteeringInfantry& steering_infantry, SteeringInfantryCommand& steering_infantry_command,
+            std::string_view board_serial = {})
             : librmcs::agent::RmcsBoardLite(board_serial)
-            , tf_(climbable_infantry.tf_)
+            , tf_(steering_infantry.tf_)
             , imu_(1000, 0.2, 0.0)
-            , dr16_(climbable_infantry)
-            , gimbal_yaw_motor_(climbable_infantry, climbable_infantry_command, "/gimbal/yaw")
-            , supercap_(climbable_infantry, climbable_infantry_command)
+            , dr16_(steering_infantry)
+            , gimbal_yaw_motor_(steering_infantry, steering_infantry_command, "/gimbal/yaw")
+            , supercap_(steering_infantry, steering_infantry_command)
             , gimbal_bullet_feeder_(
-                  climbable_infantry, climbable_infantry_command, "/gimbal/bullet_feeder")
+                  steering_infantry, steering_infantry_command, "/gimbal/bullet_feeder")
             , chassis_front_steering_motors_(
-                  {climbable_infantry, climbable_infantry_command, "/chassis/left_front_steering"},
-                  {climbable_infantry, climbable_infantry_command, "/chassis/right_front_steering"})
+                  {steering_infantry, steering_infantry_command, "/chassis/left_front_steering"},
+                  {steering_infantry, steering_infantry_command, "/chassis/right_front_steering"})
             , chassis_front_wheel_motors_(
-                  {climbable_infantry, climbable_infantry_command, "/chassis/left_front_wheel"},
-                  {climbable_infantry, climbable_infantry_command, "/chassis/right_front_wheel"})
+                  {steering_infantry, steering_infantry_command, "/chassis/left_front_wheel"},
+                  {steering_infantry, steering_infantry_command, "/chassis/right_front_wheel"})
             , chassis_back_steering_motors_(
-                  {climbable_infantry, climbable_infantry_command, "/chassis/left_back_steering"},
-                  {climbable_infantry, climbable_infantry_command, "/chassis/right_back_steering"})
+                  {steering_infantry, steering_infantry_command, "/chassis/left_back_steering"},
+                  {steering_infantry, steering_infantry_command, "/chassis/right_back_steering"})
             , chassis_back_wheel_motors_(
-                  {climbable_infantry, climbable_infantry_command, "/chassis/left_back_wheel"},
-                  {climbable_infantry, climbable_infantry_command, "/chassis/right_back_wheel"}) {
+                  {steering_infantry, steering_infantry_command, "/chassis/left_back_wheel"},
+                  {steering_infantry, steering_infantry_command, "/chassis/right_back_wheel"}) {
             gimbal_yaw_motor_.configure(
                 device::LkMotor::Config{device::LkMotor::Type::kMG4010Ei10}.set_encoder_zero_point(
                     static_cast<int>(
-                        climbable_infantry.get_parameter("yaw_motor_zero_point").as_int())));
+                        steering_infantry.get_parameter("yaw_motor_zero_point").as_int())));
             gimbal_bullet_feeder_.configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kM3508}
                     .set_reversed()
@@ -277,25 +276,25 @@ private:
                 device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
                     .set_encoder_zero_point(
                         static_cast<int>(
-                            climbable_infantry.get_parameter("left_front_zero_point").as_int()))
+                            steering_infantry.get_parameter("left_front_zero_point").as_int()))
                     .set_reversed());
             chassis_front_steering_motors_[1].configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
                     .set_encoder_zero_point(
                         static_cast<int>(
-                            climbable_infantry.get_parameter("right_front_zero_point").as_int()))
+                            steering_infantry.get_parameter("right_front_zero_point").as_int()))
                     .set_reversed());
             chassis_back_steering_motors_[0].configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
                     .set_encoder_zero_point(
                         static_cast<int>(
-                            climbable_infantry.get_parameter("left_back_zero_point").as_int()))
+                            steering_infantry.get_parameter("left_back_zero_point").as_int()))
                     .set_reversed());
             chassis_back_steering_motors_[1].configure(
                 device::DjiMotor::Config{device::DjiMotor::Type::kGM6020}
                     .set_encoder_zero_point(
                         static_cast<int>(
-                            climbable_infantry.get_parameter("right_back_zero_point").as_int()))
+                            steering_infantry.get_parameter("right_back_zero_point").as_int()))
                     .set_reversed());
 
             chassis_front_wheel_motors_[0].configure(
@@ -315,7 +314,7 @@ private:
                     .set_reversed()
                     .set_reduction_ratio(2232. / 169.));
 
-            climbable_infantry.register_output("/referee/serial", referee_serial_);
+            steering_infantry.register_output("/referee/serial", referee_serial_);
             referee_serial_->read = [this](std::byte* buffer, size_t size) {
                 return referee_ring_buffer_receive_.pop_front_n(
                     [&buffer](std::byte byte) noexcept { *buffer++ = byte; }, size);
@@ -326,7 +325,7 @@ private:
                 return size;
             };
 
-            climbable_infantry.register_output(
+            steering_infantry.register_output(
                 "/chassis/yaw/velocity_imu", chassis_yaw_velocity_imu_, 0);
         }
 


### PR DESCRIPTION
- Convert the active climbable-infantry line into the maintained steering-infantry variant. Remove the stair-climbing control chain and dedicated climber motors, revert the temporary VT13 / merged-remote stack back to pure DR16, and rename the cleaned result back to steering-infantry because the historical steering-infantry is no longer maintained.
- Update SteeringInfantry to the rmcs-board-lite split top/bottom board path and refresh its bringup config for the current robot. Also restore the original /gimbal/calibrate and /steers/calibrate semantics, remove the temporary yaw watchdog path, make pitch control explicitly use LK velocity commands, and recover accidentally removed mainline content while keeping only the required steering-infantry merge delta.

Update librmcs from v3.2.0b0 to v3.2.0 for the required board-lite SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 变更概览

本 PR 将活跃的 climbable-infantry 行合并为维护分支 steering-infantry，保留 steering-infantry 的实现路径并折叠 climbable-infantry 的改动。目标是简化硬件/控制栈、恢复主线遥控栈并迁移到 board-lite SDK。主要变更包括配置、依赖与硬件实现重构，并恢复若干控制语义。

### 核心目标（来自 PR 描述）
- 将 climbable-infantry 的改动折叠入 maintained steering-infantry。
- 移除爬梯（stair-climbing）控制链与专用爬梯电机。
- 将临时 VT13/merged-remote 堆栈还原为纯 DR16。
- 将清理后的结果命名回 steering-infantry（原历史 steering-infantry 已不再维护）。
- 使 SteeringInfantry 采用 rmcs-board-lite 的 top/bottom 分离板路径，并刷新当前机器的 bringup 配置。
- 恢复原始 /gimbal/calibrate 与 /steers/calibrate 语义。
- 移除临时的 yaw 看门狗路径。
- 使 pitch 控制明确使用 LK 速度命令。
- 恢复意外被移除的主线内容，仅保留 steering-infantry 合并的差异。
- 将 librmcs 从 v3.2.0b0 升级到 v3.2.0，以获得 board-lite SDK。

### 主要文件变更摘要

1) rmcs_ws/src/rmcs_bringup/config/steering-infantry.yaml
- 组件别名与 rmcs_executor 映射调整：将 SteeringInfantry 硬件别名改为 infantry_hardware；启用 referee_ui_infantry 的映射等。
- 云台/舵机 PID 与话题路径调整：更新 pitch_angle_pid_controller、yaw_angle_pid_controller 的测量/控制/设定话题与 PID 参数，新增并启用 yaw_velocity_pid_controller（用于偏航速度控制）。
- 硬件序列号、电机零点、gimbal_controller 限值更新；摩擦轮目标速度从 600.0 调整为 590.0，软启动/停止时间从 1.0 调为 0.3。
- 射击子系统参数调整：bullet_feeder_controller 的 bullets_per_feeder_turn 与 shot_frequency 变更；shooting_recorder 的 friction_wheel_count 与 log_mode 更新；bullet_feeder_velocity_pid_controller、steering_wheel_controller 的若干参数（kp/ki/kd、mess、moment_of_inertia、vehicle_radius）被修改。
- 恢复并重组交互/裁判相关映射（Interaction/Ui/Command 等）。

2) rmcs_ws/src/rmcs_core/CMakeLists.txt
- 将 FetchContent 中的 librmcs 版本从 v3.2.0-beta.0 切换到 v3.2.0，并更新对应的下载哈希（SHA256），以获取 board-lite SDK 支持。

3) rmcs_ws/src/rmcs_core/src/hardware/steering-infantry.cpp
- 将板基类从 CBoard 切换为 RmcsBoardLite，重构 TopBoard/BottomBoard 的实现以匹配 board-lite 分离式上/下板设计。
- TopBoard 调整：
  - 统一使用 imu_ 命名并更新 IMU 输出引用（仍使用 device::Bmi088 作为 IMU）。
  - 修改 CAN 命令/接收映射：俯仰相关 CAN ID 切换到 0x143，摩擦舵机接收 ID 从 0x203/0x204 改为 0x201/0x202。
  - command_update 中的 CAN 打包/发送顺序与速度命令生成逻辑被重写。
  - 校准回调中 steers 零点日志改为引用 BottomBoard 重组后的前/后舵机分组结构。
- BottomBoard 调整：
  - 移除基于 can_transmission_mode_ 的分支发送逻辑，改为固定多 CAN 通道发送：can0（后轮/后舵机/超容）、can1（前轮/前舵机）、can2（云台 yaw 扭矩，ID 0x142）、can3（弹丸供弹，ID 0x1FF）。
  - 接收回调按 can0/can1/can2/can3 映射回填对应电机/供电/云台状态；uart0 收到数据写入 referee_ring_buffer_receive_，DBus 数据写入 dr16_。
  - 成员结构重组：移除外层模式/功率计输出成员，电机数组由较大数组收敛为前/后分组的更小数组，yaw 速度从 imu_.gy() 改为 imu_.gz() 写入 chassis_yaw_velocity_imu_，并将 dr16_ 与相关回调内聚到 BottomBoard。
- 整体上对 CAN ID、发送/接收映射、成员命名与数据流做了广泛重构以适配 board-lite 与 DR16 恢复。

### 风险与审查要点（从改动体量与性质推断）
- 大量 CAN ID 与发送/接收路径变更，需在实际硬件上验证电机/云台/供电的 CAN 映射与方向是否正确。
- board-lite 基类切换与成员重组可能影响原先其它模块对 SteeringInfantry 成员或话题的假设（注意外部接口兼容性）。
- PID 与控制器话题的变更需要在闭环下进行调参验证，尤其 yaw_velocity_pid 的新增与 friction wheel、feeder 的参数修改。
- 依赖版本变更（librmcs v3.2.0）需在 CI/构建环境中验证下载校验与编译兼容性。

### 其他元信息
- 作者：qzhhhi 请求 `@coderabbitai` 审核；CodeRabbit 机器人触发了自动回复，当前无人工审阅评论。
- 提交信息较简短（单条 commit message："fix naming"），PR 描述提供了意图和要点。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->