### PR TITLE
feat(gimbal): use robot_center for dual-yaw targeting and tune PID params

### DIFF
--- a/rmcs_ws/src/rmcs_bringup/config/sentry.yaml
+++ b/rmcs_ws/src/rmcs_bringup/config/sentry.yaml
@@ -39,7 +39,7 @@ sentry_hardware:
     board_serial_bottom_board: "af-79cf"
     board_serial_gimbal_board: "af-8b8b"
 
-    pitch_motor_zero_point: 12347
+    pitch_motor_zero_point: 12158
 
     bottom_yaw_motor_zero_point: 54551
     top_yaw_motor_zero_point: 33409
@@ -61,22 +61,22 @@ gimbal_controller:
     upper_limit: -0.65
     lower_limit: 0.36
 
-    top_yaw_angle_kp: 45.0
-    top_yaw_angle_ki: 0.0
-    top_yaw_angle_kd: 0.0
+    top_yaw_angle_kp: 35.0
+    top_yaw_angle_ki: 0.008
+    top_yaw_angle_kd: 0.005
     top_yaw_velocity_kp: 2.160
-    top_yaw_velocity_ki: 0.0
+    top_yaw_velocity_ki: 0.00
     top_yaw_velocity_kd: 0.0
 
-    bottom_yaw_angle_kp: 12.0
-    bottom_yaw_angle_ki: 0.0
-    bottom_yaw_angle_kd: 0.0
-    bottom_yaw_velocity_kp: 22.5
-    bottom_yaw_velocity_ki: 0.0
-    bottom_yaw_velocity_kd: 0.0
+    bottom_yaw_angle_kp: 9.5
+    bottom_yaw_angle_ki: 0.001
+    bottom_yaw_angle_kd: 0.0003
+    bottom_yaw_velocity_kp: 18.0
+    bottom_yaw_velocity_ki: 0.00
+    bottom_yaw_velocity_kd: 0.00
 
     pitch_angle_kp: 32.0
-    pitch_angle_ki: 0.0
+    pitch_angle_ki: 0.01
     pitch_angle_kd: 0.0
     pitch_velocity_kp: 2.5
     pitch_velocity_ki: 0.0

--- a/rmcs_ws/src/rmcs_core/src/controller/gimbal/eccentric_dual_yaw.cpp
+++ b/rmcs_ws/src/rmcs_core/src/controller/gimbal/eccentric_dual_yaw.cpp
@@ -54,11 +54,27 @@ public:
             const auto xy_norm = std::hypot(dir.x(), dir.y());
             const auto pitch =
                 std::clamp(std::atan2(-dir.z(), xy_norm), upper_limit_, lower_limit_);
-            const auto yaw = std::atan2(dir.y(), dir.x());
+            const auto control_yaw = std::atan2(dir.y(), dir.x());
+
+            const auto camera_pose = fast_tf::lookup_transform<OdomImu, CameraLink>(*input_.tf);
+            const auto camera_pos = camera_pose.translation();
+            const auto robot_center = *input_.auto_aim_robot_center;
+            Eigen::Vector3d diff{
+                robot_center.x() - camera_pos.x(),
+                robot_center.y() - camera_pos.y(),
+                robot_center.z() - camera_pos.z(),
+            };
+            double center_yaw;
+            if (diff.norm() > 1e-9) {
+                diff.normalize();
+                center_yaw = std::atan2(diff.y(), diff.x());
+            } else {
+                center_yaw = 0.0;
+            }
 
             const auto command = ControlTarget{
-                .bottom_yaw = {.target = yaw},
-                .top_yaw = {.target = 0.0},
+                .bottom_yaw = {.target = center_yaw},
+                .top_yaw = {.target = limit_rad(control_yaw - center_yaw)},
                 .pitch = {.target = pitch},
             };
             apply_control(command);
@@ -170,6 +186,7 @@ private:
             component.register_input("/auto_aim/pitch_rate", auto_aim_pitch_rate, false);
             component.register_input("/auto_aim/yaw_acc", auto_aim_yaw_acc, false);
             component.register_input("/auto_aim/pitch_acc", auto_aim_pitch_acc, false);
+            component.register_input("/auto_aim/robot_center", auto_aim_robot_center, false);
             component.register_input(
                 "/rmcs_navigation/enable_control", navigation_enable_control, false);
             component.register_input("/rmcs_navigation/gimbal_toward", navigation_toward, false);
@@ -191,8 +208,12 @@ private:
             if (!auto_aim_control_direction.ready())
                 return false;
             const auto& dir = *auto_aim_control_direction;
+            if (!auto_aim_robot_center.ready())
+                return false;
+            const auto& center = *auto_aim_robot_center;
             return !dir.isZero() && std::isfinite(dir.x()) && std::isfinite(dir.y())
-                && std::isfinite(dir.z());
+                && std::isfinite(dir.z()) && !center.isZero() && std::isfinite(center.x())
+                && std::isfinite(center.y()) && std::isfinite(center.z());
         }
 
         auto enable_navigation() const noexcept -> bool {
@@ -220,6 +241,7 @@ private:
         InputInterface<double> chassis_yaw_velocity_imu;
 
         InputInterface<Eigen::Vector3d> auto_aim_control_direction;
+        InputInterface<Eigen::Vector3d> auto_aim_robot_center;
         InputInterface<double> auto_aim_yaw_rate;
         InputInterface<double> auto_aim_pitch_rate;
         InputInterface<double> auto_aim_yaw_acc;
@@ -379,12 +401,12 @@ private:
                 pitch_velocity_ref)
             + pitch_gravity_ff_gain_ * std::sin(current_pitch_angle - pitch_gravity_ff_phase_);
 
-        *output_.bottom_yaw_control_torque =
-            bottom_yaw_velocity_pid_.update(bottom_velocity_ref - current_bottom_velocity)
-            + bottom_yaw_torque_ff;
         *output_.top_yaw_control_torque =
             top_yaw_velocity_pid_.update(top_velocity_ref - *input_.top_yaw_velocity)
             + top_yaw_torque_ff;
+        *output_.bottom_yaw_control_torque =
+            bottom_yaw_velocity_pid_.update(bottom_velocity_ref - current_bottom_velocity)
+            + bottom_yaw_torque_ff;
         *output_.pitch_control_torque =
             pitch_velocity_pid_.update(pitch_velocity_ref - *input_.pitch_velocity)
             + pitch_torque_ff;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 功能变更

### 配置参数调整 (sentry.yaml)

**云台硬件参数**
- 调整 `pitch_motor_zero_point` 从 12347 至 12158

**云台控制器PID参数优化**
- 上层偏航角度PID：`kp: 45.0 → 35.0`，`ki: 0.0 → 0.008`，`kd: 0.0 → 0.005`
- 上层偏航速度PID：`ki: 0.0 → 0.00`，`kd` 保持 0.0（`kp` 保持 2.160）
- 下层偏航角度PID：`kp: 12.0 → 9.5`，`ki: 0.0 → 0.001`，`kd: 0.0 → 0.0003`
- 下层偏航速度PID：`kp: 22.5 → 18.0`（`ki/kd` 保持 0.00/0.00）
- 俯仰角度积分项：`ki: 0.0 → 0.01`

### 核心控制逻辑更新 (eccentric_dual_yaw.cpp)

**双偏航自瞄目标计算改进**
- 新增 `auto_aim_robot_center` 输入接口，用于接收机器人中心点坐标
- 自瞄模式下，计算相机位置到机器人中心的向量方向，作为 `center_yaw` 
- 下层偏航目标从直接使用瞄准yaw改为设置为计算的 `center_yaw`
- 上层偏航目标从固定为0改为设置为期望瞄准yaw与 `center_yaw` 的有限角度差

**自瞄启用条件增强**
- 新增对 `auto_aim_robot_center` 就绪状态的检查
- 新增对机器人中心坐标非零且所有分量有限的验证

**代码结构优化**
- 重新排列 `apply_control()` 方法中上下层偏航转矩的计算和赋值顺序（上层优先）

## 影响范围

- Sentry哨兵机器人的云台控制参数配置
- 自动瞄准系统的双偏航协调算法

<!-- end of auto-generated comment: release notes by coderabbit.ai -->